### PR TITLE
Isolate mutable test sidecars

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -52,6 +52,8 @@ pub fn build(b: *std.Build) void {
     // Required for this suite on current Zig/OS (same as test_validate).
     test_index_module.link_libc = true;
     const run_test_index = b.addRunArtifact(b.addTest(.{ .root_module = test_index_module }));
+    // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
+    run_test_index.step.dependOn(b.getInstallStep());
 
     const run_test_get = b.addRunArtifact(b.addTest(.{
         .root_module = b.createModule(.{
@@ -122,6 +124,8 @@ pub fn build(b: *std.Build) void {
     // Required for this suite on current Zig/OS (same as test_index).
     test_validate_module.link_libc = true;
     const run_test_validate = b.addRunArtifact(b.addTest(.{ .root_module = test_validate_module }));
+    // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
+    run_test_validate.step.dependOn(b.getInstallStep());
 
     run_test_index.step.dependOn(&gen_messy_fixtures.step);
     run_test_validate.step.dependOn(&gen_messy_fixtures.step);

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -646,9 +646,12 @@ test "CLI failures: get usage, conflicts, and missing sequence" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-    const fasta = "tests/data/simple.fasta";
 
-    // Ensure index exists so "sequence not found" is not a missing-index failure.
+    const fasta = try writeFastaArtifact(allocator, "get-cli-errors", @embedFile("data/simple.fasta"));
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
+
     {
         var threaded = std.Io.Threaded.init(allocator, .{});
         defer threaded.deinit();

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -496,7 +496,7 @@ test "writeZfiIndexFile creates valid production layout" {
         .{ .name_offset = 1, .name_len = 4, .seq_offset = 10, .seq_len = 100, .line_bases = 80, .line_bytes = 81 },
     };
 
-    const path = "tests/data/test_write.zfi";
+    const path = try uniqueArtifactPath(allocator, "test-write", "zfi");
     defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
 
     try writeZfiFromRecords(path, &records, 1000, 0, allocator);


### PR DESCRIPTION
## Summary

  - isolate the remaining mutable test sidecars
  - keep shared fixture sidecars read-only during parallel tests

  ## Validation

  - Debug and ReleaseFast test suites
  - 100 repeated Debug runs with distinct seeds
  - 100 repeated ReleaseFast runs with distinct seeds

  This is a work in progress. The original CI failure was not locally reproducible, so cross-platform CI remains the deciding evidence.