### PR TITLE
chore: standardize code quality and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,31 +63,15 @@ jobs:
           - name: Linux x86_64
             os: ubuntu-24.04
             binary: ./zig-out/bin/z-fasta
-            target_flag: ""
           - name: Linux aarch64
             os: ubuntu-24.04-arm
             binary: ./zig-out/bin/z-fasta
-            target_flag: ""
-          - name: Windows x86_64
-            os: windows-2025
-            binary: ./zig-out/bin/z-fasta.exe
-            target_flag: ""
-          # Zig 0.16.0 aarch64-windows host binary segfaults (bootstrap poison).
-          # Use x86_64 Zig under WoA emulation and cross-build aarch64-windows so
-          # smoke/tests still run native ARM binaries on the runner.
-          # https://codeberg.org/ziglang/zig/issues/31865
-          - name: Windows aarch64
-            os: windows-11-arm
-            binary: ./zig-out/bin/z-fasta.exe
-            target_flag: "-Dtarget=aarch64-windows"
           - name: macOS aarch64
             os: macos-15
             binary: ./zig-out/bin/z-fasta
-            target_flag: ""
           - name: macOS x86_64
             os: macos-15-intel
             binary: ./zig-out/bin/z-fasta
-            target_flag: ""
 
     steps:
       - uses: actions/checkout@v7
@@ -95,23 +79,16 @@ jobs:
           persist-credentials: false
 
       - name: Setup Zig
-        if: matrix.os != 'windows-11-arm'
         uses: mlugg/setup-zig@v2
         with:
           version: 0.16.0
           cache-key: ${{ matrix.name }}
-
-      - name: Setup Zig (Windows aarch64 host workaround)
-        if: matrix.os == 'windows-11-arm'
-        shell: bash
-        run: .github/scripts/setup_zig_windows_arm.sh
 
       - name: Runner diagnostics
         shell: bash
         run: |
           echo "runner_os=${RUNNER_OS}"
           echo "runner_arch=${RUNNER_ARCH}"
-          echo "target_flag=${{ matrix.target_flag }}"
           zig version
 
       - name: Run tests (Debug safety lane)
@@ -120,14 +97,8 @@ jobs:
         run: zig build test --summary all
 
       - name: Run tests (ReleaseFast ship mode)
-        if: matrix.name != 'Windows aarch64'
         shell: bash
-        run: zig build test -Doptimize=ReleaseFast --summary all ${{ matrix.target_flag }}
-
-      - name: Build (Windows aarch64 ship mode)
-        if: matrix.name == 'Windows aarch64'
-        shell: bash
-        run: zig build -Doptimize=ReleaseFast ${{ matrix.target_flag }}
+        run: zig build test -Doptimize=ReleaseFast --summary all
 
       - name: Smoke test
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,4 @@ tmp/
 ref/
 temp/
 plan/
-assets/
 experiments/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to z-fasta will be documented in this file.
 
 ## Unreleased
 
-Single-path performance and memory cleanup across `index`, `get`, and `stats`. No `.zfi` format change. **Re-index not required.**
+Single-path performance and memory cleanup across `index`, `get`, and `stats`, with CLI and validation hardening. No `.zfi` format change. **Re-index not required.**
 
 ### Changed
 
@@ -43,13 +43,23 @@ Single-path performance and memory cleanup across `index`, `get`, and `stats`. N
 
 ### Fixed
 
+- **CLI and Get**
+  - `index` and `stats` reject extra FASTA paths. `validate` rejects `-o` and `--fix-format-only` unless `--fix` is present.
+  - BED coordinates require unsigned decimal fields, and large grouped GET requests fall back to bounded per-region reads when they exceed the shared buffer.
+
 - **Index**
   - Indexing rejects a detected source size or modification-time change before publishing `.zfi` or replaying `.fai` output.
+  - Sequence lines above the index geometry limit fail cleanly, `.zfi` publication uses independent atomic files, and loaders reject overlapping non-uniform side-table spans.
   - `.fai` stdout write and flush failures return an error, and temporary output is cleaned after handled success or failure.
 
 - **Stats**
   - `auN`, percentages, and GC skew use overflow-safe integer arithmetic and exact rounding.
   - Invalid index geometry, mismatched sequence totals, read failures, and write failures now stop cleanly.
+
+- **Validate**
+  - `--fix` writes atomically and refuses output paths that resolve to the input file.
+  - Counts, remaining warnings, and fix blockers stay complete after the 10000-event report cap.
+  - Final sequence lines wider than the established width are reported, and B, Z, and J are accepted protein ambiguity codes.
 
 ## [0.3.1] - 2026-08-02
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   <a href="https://ziglang.org/download/0.16.0/"><img src="https://img.shields.io/badge/Zig-0.16.0-F7A41D?style=for-the-badge&logo=zig&logoColor=white" alt="Zig 0.16.0" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-6366f1?style=for-the-badge" alt="License: MIT" /></a>
 </div>
-<!-- markdownlint-enable MD041 -->
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- markdownlint-disable MD033 MD036 MD041 -->
 <div align="center">
-  <h1>z-fasta</h1>
+  <img src="assets/logo-readme.svg" alt="z-fasta" width="220">
   <p>
     Fast, modular FASTA toolkit built in Zig.<br/>
     SIMD-accelerated indexing, O(1) region extraction, validation, and assembly stats.<br/>

--- a/assets/icon.svg
+++ b/assets/icon.svg
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 160 122"
+   role="img"
+   aria-labelledby="title description"
+   version="1.1"
+   id="svg3"
+   sodipodi:docname="icon.svg"
+   width="160"
+   height="122"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.4322484"
+     inkscape:cx="36.407846"
+     inkscape:cy="79.931232"
+     inkscape:window-width="3840"
+     inkscape:window-height="2089"
+     inkscape:window-x="2160"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <title
+     id="title">z-fasta</title>
+  <desc
+     id="description">The name z-fasta rendered as an orange lightning Z followed by a white hyphen and letters, with both letter a characters replaced by orange FASTA chevrons.</desc>
+  <!-- Stylized lightning Z -->
+  <!-- -f>st> spells -fasta with FASTA header markers in place of a -->
+  <g
+     id="g7"
+     transform="translate(0,-0.26240778)">
+    <rect
+       x="2.8085542"
+       y="2.8085542"
+       width="154.38289"
+       height="116.90771"
+       rx="27.067131"
+       fill="#151515"
+       stroke="#f7a41d"
+       stroke-width="3"
+       id="rect1" />
+    <g
+       id="g6"
+       transform="translate(0,-20.027031)">
+      <g
+         id="g5"
+         transform="translate(-0.11859233,-0.59296166)">
+        <g
+           fill="#f7a41d"
+           id="g12"
+           transform="matrix(0.28379533,0,0,0.28379533,0.6680128,63.120163)">
+          <g
+             id="g8"
+             transform="translate(28.189329,-3.8881397)">
+            <polygon
+               points="62,36 37,44 56,22 "
+               id="polygon4" />
+            <polygon
+               points="111,44 37,44 56,32 56,22 111,22 "
+               shape-rendering="crispEdges"
+               id="polygon5" />
+            <polygon
+               points="97,117 90,104 116,95 "
+               id="polygon6" />
+            <polygon
+               points="97,117 42,117 42,95 116,95 100,104 "
+               shape-rendering="crispEdges"
+               id="polygon7" />
+            <polygon
+               points="3,140 101,22 150,0 52,117 "
+               id="polygon8" />
+          </g>
+        </g>
+      </g>
+      <g
+         font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace"
+         font-size="25px"
+         font-weight="700"
+         id="g3"
+         transform="matrix(1.1082014,0,0,1.1082014,-13.794243,-7.5986864)">
+        <g
+           id="g4"
+           transform="matrix(1.2193877,0,0,1.2193877,-11.169888,-27.415717)">
+          <text
+             x="50"
+             y="94.953125"
+             fill="#f4eed7"
+             id="text1">-f st</text>
+          <text
+             x="78.322853"
+             y="94.677147"
+             fill="#f7a41d"
+             id="text2">&gt;</text>
+          <text
+             x="117.87634"
+             y="94.953125"
+             fill="#f7a41d"
+             id="text3">&gt;</text>
+        </g>
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata3">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>z-fasta</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/assets/logo-readme.svg
+++ b/assets/logo-readme.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 160 122"
+   role="img"
+   aria-labelledby="title description"
+   version="1.1"
+   id="svg3"
+   width="160"
+   height="122"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3" />
+  <sodipodi:namedview
+     id="namedview3"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8.4322484"
+     inkscape:cx="36.407846"
+     inkscape:cy="79.931232"
+     inkscape:window-width="3840"
+     inkscape:window-height="2089"
+     inkscape:window-x="2160"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3" />
+  <title
+     id="title">z-fasta</title>
+  <desc
+     id="description">The name z-fasta rendered as an orange lightning Z followed by a white hyphen and letters, with both letter a characters replaced by orange FASTA chevrons.</desc>
+  <!-- Stylized lightning Z -->
+  <!-- -f>st> spells -fasta with FASTA header markers in place of a -->
+  <g
+     id="g7"
+     transform="translate(0,-0.26240778)">
+    <rect
+       x="2.8085542"
+       y="2.8085542"
+       width="154.38289"
+       height="116.90771"
+       rx="27.067131"
+       fill="#151515"
+       stroke="#f7a41d"
+       stroke-width="3"
+       id="rect1" />
+    <g
+       id="g6"
+       transform="translate(0,-20.027031)">
+      <g
+         id="g5"
+         transform="translate(-0.11859233,-0.59296166)">
+        <g
+           fill="#f7a41d"
+           id="g12"
+           transform="matrix(0.28379533,0,0,0.28379533,0.6680128,63.120163)">
+          <g
+             id="g8"
+             transform="translate(28.189329,-3.8881397)">
+            <polygon
+               points="62,36 37,44 56,22 "
+               id="polygon4" />
+            <polygon
+               points="111,44 37,44 56,32 56,22 111,22 "
+               shape-rendering="crispEdges"
+               id="polygon5" />
+            <polygon
+               points="97,117 90,104 116,95 "
+               id="polygon6" />
+            <polygon
+               points="97,117 42,117 42,95 116,95 100,104 "
+               shape-rendering="crispEdges"
+               id="polygon7" />
+            <polygon
+               points="3,140 101,22 150,0 52,117 "
+               id="polygon8" />
+          </g>
+        </g>
+      </g>
+      <g
+         font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace"
+         font-size="25px"
+         font-weight="700"
+         id="g3"
+         transform="matrix(1.1082014,0,0,1.1082014,-13.794243,-7.5986864)">
+        <g
+           id="g4"
+           transform="matrix(1.2193877,0,0,1.2193877,-11.169888,-27.415717)">
+          <text
+             x="50"
+             y="94.953125"
+             fill="#f4eed7"
+             id="text1">-f st</text>
+          <text
+             x="78.322853"
+             y="94.677147"
+             fill="#f7a41d"
+             id="text2">&gt;</text>
+          <text
+             x="117.87634"
+             y="94.953125"
+             fill="#f7a41d"
+             id="text3">&gt;</text>
+        </g>
+      </g>
+    </g>
+  </g>
+  <metadata
+     id="metadata3">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>z-fasta</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,15 @@ pub fn build(b: *std.Build) void {
     // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
     run_test_get.step.dependOn(b.getInstallStep());
 
+    const run_test_getter_unit = b.addRunArtifact(b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/getter.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+        .filters = &.{"getter.test."},
+    }));
+
     const run_test_stats = b.addRunArtifact(b.addTest(.{
         .root_module = b.createModule(.{
             .root_source_file = b.path("tests/test_stats.zig"),
@@ -112,6 +121,7 @@ pub fn build(b: *std.Build) void {
         const gen_test_index = b.addRunArtifact(exe);
         gen_test_index.addArgs(&.{ "index", fasta_path });
         run_test_get.step.dependOn(&gen_test_index.step);
+        run_test_getter_unit.step.dependOn(&gen_test_index.step);
         run_test_stats.step.dependOn(&gen_test_index.step);
     }
 
@@ -133,6 +143,7 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_test_index.step);
     test_step.dependOn(&run_test_get.step);
+    test_step.dependOn(&run_test_getter_unit.step);
     test_step.dependOn(&run_test_stats.step);
     test_step.dependOn(&run_test_complement.step);
     test_step.dependOn(&run_test_bed_parser.step);

--- a/build.zig
+++ b/build.zig
@@ -1,11 +1,11 @@
-//! Product build: z-fasta exe (ReleaseFast + strip by default) and unit/integration tests.
+//! Builds the z-fasta executable and its unit, integration, and CLI test suites.
 
 const std = @import("std");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    // Ship path is ReleaseFast + strip. ReleaseSmall slows .text; reject it.
+    // ReleaseSmall regresses the text hot path; ReleaseFast is the supported ship mode.
     if (optimize == .ReleaseSmall) {
         std.debug.print(
             "error: ReleaseSmall is unsupported; use -Doptimize=ReleaseFast (strips by default)\n",
@@ -13,7 +13,7 @@ pub fn build(b: *std.Build) void {
         );
         std.process.exit(1);
     }
-    // Zig auto-strips only ReleaseSmall; RF needs an explicit strip flag.
+    // ReleaseFast does not enable stripping automatically.
     const strip = b.option(bool, "strip", "Strip debug info") orelse (optimize != .Debug);
 
     const exe = b.addExecutable(.{
@@ -49,10 +49,10 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
         .imports = &.{.{ .name = "main", .module = main_module }},
     });
-    // Required for this suite on current Zig/OS (same as test_validate).
+    // Timestamp tests call POSIX time functions through std.c.
     test_index_module.link_libc = true;
     const run_test_index = b.addRunArtifact(b.addTest(.{ .root_module = test_index_module }));
-    // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
+    // CLI-bearing suites spawn the installed path, so keep it current.
     run_test_index.step.dependOn(b.getInstallStep());
 
     const run_test_get = b.addRunArtifact(b.addTest(.{
@@ -63,10 +63,10 @@ pub fn build(b: *std.Build) void {
             .imports = &.{.{ .name = "main", .module = main_module }},
         }),
     }));
-    // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
     run_test_get.step.dependOn(b.getInstallStep());
 
     const run_test_main_unit = b.addRunArtifact(b.addTest(.{ .root_module = main_module }));
+    run_test_main_unit.step.dependOn(b.getInstallStep());
 
     const run_test_indexer_unit = b.addRunArtifact(b.addTest(.{
         .root_module = b.createModule(.{
@@ -86,46 +86,34 @@ pub fn build(b: *std.Build) void {
     }));
     run_test_stats.step.dependOn(b.getInstallStep());
 
-    // Messy correctness FASTAs live in gitignored cache; materialize before tests that read them.
-    const gen_messy_fixtures = b.addSystemCommand(&.{
-        "python3",
-        "bench/shared/generate_messy.py",
-        "--fixtures",
-    });
+    // Generate ignored sidecars so tests also pass on a clean checkout.
+    const gen_simple_index = b.addRunArtifact(exe);
+    gen_simple_index.addArgs(&.{ "index", "tests/data/simple.fasta" });
+    run_test_index.step.dependOn(&gen_simple_index.step);
+    run_test_get.step.dependOn(&gen_simple_index.step);
+    run_test_main_unit.step.dependOn(&gen_simple_index.step);
+    run_test_stats.step.dependOn(&gen_simple_index.step);
 
-    // GET and stats subprocess tests load sidecars from tests/data. Generate them
-    // with the selected build mode so `zig build test` works on a clean checkout.
-    const test_fasta_paths = [_][]const u8{
-        "tests/data/simple.fasta",
-        "tests/data/proteome.fasta",
-        "tests/data/single.fasta",
-        "tests/data/edge_cases.fasta",
-        "tests/data/mixed_widths.fasta",
-    };
-    for (test_fasta_paths) |fasta_path| {
-        const gen_test_index = b.addRunArtifact(exe);
-        gen_test_index.addArgs(&.{ "index", fasta_path });
-        run_test_get.step.dependOn(&gen_test_index.step);
-        run_test_main_unit.step.dependOn(&gen_test_index.step);
-        run_test_stats.step.dependOn(&gen_test_index.step);
-    }
+    const gen_proteome_index = b.addRunArtifact(exe);
+    gen_proteome_index.addArgs(&.{ "index", "tests/data/proteome.fasta" });
+    run_test_get.step.dependOn(&gen_proteome_index.step);
+    run_test_stats.step.dependOn(&gen_proteome_index.step);
 
-    const test_validate_module = b.createModule(.{
-        .root_source_file = b.path("tests/test_validate.zig"),
-        .target = target,
-        .optimize = optimize,
-        .imports = &.{.{ .name = "main", .module = main_module }},
-    });
-    // Required for this suite on current Zig/OS (same as test_index).
-    test_validate_module.link_libc = true;
-    const run_test_validate = b.addRunArtifact(b.addTest(.{ .root_module = test_validate_module }));
-    // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
+    const gen_edge_cases_index = b.addRunArtifact(exe);
+    gen_edge_cases_index.addArgs(&.{ "index", "tests/data/edge_cases.fasta" });
+    run_test_get.step.dependOn(&gen_edge_cases_index.step);
+
+    const run_test_validate = b.addRunArtifact(b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/test_validate.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{.{ .name = "main", .module = main_module }},
+        }),
+    }));
     run_test_validate.step.dependOn(b.getInstallStep());
 
-    run_test_index.step.dependOn(&gen_messy_fixtures.step);
-    run_test_validate.step.dependOn(&gen_messy_fixtures.step);
-
-    const test_step = b.step("test", "Run unit tests");
+    const test_step = b.step("test", "Run tests");
     test_step.dependOn(&run_test_index.step);
     test_step.dependOn(&run_test_get.step);
     test_step.dependOn(&run_test_main_unit.step);

--- a/build.zig
+++ b/build.zig
@@ -66,13 +66,14 @@ pub fn build(b: *std.Build) void {
     // CLI subprocess tests spawn zig-out/bin/z-fasta; keep it current with this suite.
     run_test_get.step.dependOn(b.getInstallStep());
 
-    const run_test_getter_unit = b.addRunArtifact(b.addTest(.{
+    const run_test_main_unit = b.addRunArtifact(b.addTest(.{ .root_module = main_module }));
+
+    const run_test_indexer_unit = b.addRunArtifact(b.addTest(.{
         .root_module = b.createModule(.{
-            .root_source_file = b.path("src/getter.zig"),
+            .root_source_file = b.path("src/indexer.zig"),
             .target = target,
             .optimize = optimize,
         }),
-        .filters = &.{"getter.test."},
     }));
 
     const run_test_stats = b.addRunArtifact(b.addTest(.{
@@ -84,22 +85,6 @@ pub fn build(b: *std.Build) void {
         }),
     }));
     run_test_stats.step.dependOn(b.getInstallStep());
-
-    const run_test_complement = b.addRunArtifact(b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/complement.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    }));
-
-    const run_test_bed_parser = b.addRunArtifact(b.addTest(.{
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/bed_parser.zig"),
-            .target = target,
-            .optimize = optimize,
-        }),
-    }));
 
     // Messy correctness FASTAs live in gitignored cache; materialize before tests that read them.
     const gen_messy_fixtures = b.addSystemCommand(&.{
@@ -121,7 +106,7 @@ pub fn build(b: *std.Build) void {
         const gen_test_index = b.addRunArtifact(exe);
         gen_test_index.addArgs(&.{ "index", fasta_path });
         run_test_get.step.dependOn(&gen_test_index.step);
-        run_test_getter_unit.step.dependOn(&gen_test_index.step);
+        run_test_main_unit.step.dependOn(&gen_test_index.step);
         run_test_stats.step.dependOn(&gen_test_index.step);
     }
 
@@ -143,9 +128,8 @@ pub fn build(b: *std.Build) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_test_index.step);
     test_step.dependOn(&run_test_get.step);
-    test_step.dependOn(&run_test_getter_unit.step);
+    test_step.dependOn(&run_test_main_unit.step);
+    test_step.dependOn(&run_test_indexer_unit.step);
     test_step.dependOn(&run_test_stats.step);
-    test_step.dependOn(&run_test_complement.step);
-    test_step.dependOn(&run_test_bed_parser.step);
     test_step.dependOn(&run_test_validate.step);
 }

--- a/src/bed_parser.zig
+++ b/src/bed_parser.zig
@@ -1,30 +1,18 @@
-//! BED line parser: 0-based half-open intervals to 1-based inclusive regions plus strand.
-//!
-//! Used by GET `--bed` batching (`BedRegion`, strand-aware extract).
+//! BED line parser: 0-based half-open intervals to 1-based inclusive requests.
 
 const std = @import("std");
 
 pub const BedStrand = enum {
-    plus,
-    minus,
-    none,
+    forward,
+    reverse,
     invalid,
 };
 
 pub const BedRegion = struct {
     chrom: []const u8,
-    start_0based: u64,
-    end_0based: u64,
+    start_1based: u64,
+    end_1based: u64,
     strand: BedStrand,
-    line_number: usize,
-
-    pub fn start1Based(self: BedRegion) u64 {
-        return self.start_0based + 1;
-    }
-
-    pub fn end1BasedInclusive(self: BedRegion) u64 {
-        return self.end_0based;
-    }
 };
 
 pub const ParseError = error{
@@ -42,19 +30,27 @@ pub const ParseResult = union(enum) {
 };
 
 fn parseStrand(field: []const u8) BedStrand {
-    if (field.len == 0) return .none;
+    if (field.len == 0) return .forward;
     if (field.len != 1) return .invalid;
 
     return switch (field[0]) {
-        '+' => .plus,
-        '-' => .minus,
-        '.' => .none,
+        '+', '.' => .forward,
+        '-' => .reverse,
         else => .invalid,
     };
 }
 
-/// Parses one BED line. Returned region slices borrow from `line`.
-pub fn parseBedLine(line: []const u8, line_number: usize) ParseError!ParseResult {
+fn parseCoordinate(field: []const u8) ?u64 {
+    if (std.mem.findScalar(u8, field, '_') != null) return null;
+    return std.fmt.parseUnsigned(u64, field, 10) catch null;
+}
+
+/// Parses one BED row into a 1-based inclusive request.
+///
+/// Empty, comment, track, and browser lines return `.skip`. Coordinates must
+/// contain only decimal digits and satisfy `end > start`. `chrom` borrows
+/// from `line`.
+pub fn parseBedLine(line: []const u8) ParseError!ParseResult {
     const trimmed = if (line.len > 0 and line[line.len - 1] == '\r') line[0 .. line.len - 1] else line;
 
     if (trimmed.len == 0) return .skip;
@@ -73,92 +69,21 @@ pub fn parseBedLine(line: []const u8, line_number: usize) ParseError!ParseResult
     const end_field = fields.next() orelse return error.MissingEnd;
     if (end_field.len == 0) return error.MissingEnd;
 
-    const start_0based = std.fmt.parseInt(u64, start_field, 10) catch return error.InvalidStart;
-    const end_0based = std.fmt.parseInt(u64, end_field, 10) catch return error.InvalidEnd;
+    const start_0based = parseCoordinate(start_field) orelse return error.InvalidStart;
+    const end_0based = parseCoordinate(end_field) orelse return error.InvalidEnd;
 
     if (end_0based <= start_0based) return error.EmptyInterval;
 
-    _ = fields.next(); // column 4 name, ignored
-    _ = fields.next(); // column 5 score, ignored
+    _ = fields.next();
+    _ = fields.next();
 
     const strand_field = fields.next();
-    const strand = if (strand_field) |field| parseStrand(field) else .none;
+    const strand = if (strand_field) |field| parseStrand(field) else .forward;
 
     return .{ .region = .{
         .chrom = chrom,
-        .start_0based = start_0based,
-        .end_0based = end_0based,
+        .start_1based = start_0based + 1,
+        .end_1based = end_0based,
         .strand = strand,
-        .line_number = line_number,
     } };
-}
-
-test "parseBedLine parses basic three-column BED" {
-    const parsed = try parseBedLine("chr1\t100\t200", 4);
-    switch (parsed) {
-        .skip => return error.UnexpectedResult,
-        .region => |region| {
-            try std.testing.expectEqualStrings("chr1", region.chrom);
-            try std.testing.expectEqual(@as(u64, 100), region.start_0based);
-            try std.testing.expectEqual(@as(u64, 200), region.end_0based);
-            try std.testing.expectEqual(BedStrand.none, region.strand);
-            try std.testing.expectEqual(@as(u64, 101), region.start1Based());
-            try std.testing.expectEqual(@as(u64, 200), region.end1BasedInclusive());
-            try std.testing.expectEqual(@as(usize, 4), region.line_number);
-        },
-    }
-}
-
-test "parseBedLine parses sixth-column strand" {
-    const plus = try parseBedLine("chr1\t0\t10\tname\t0\t+", 1);
-    const minus = try parseBedLine("chr1\t0\t10\tname\t0\t-", 2);
-    const dot = try parseBedLine("chr1\t0\t10\tname\t0\t.", 3);
-    const invalid = try parseBedLine("chr1\t0\t10\tname\t0\t?", 4);
-
-    try std.testing.expectEqual(BedStrand.plus, plus.region.strand);
-    try std.testing.expectEqual(BedStrand.minus, minus.region.strand);
-    try std.testing.expectEqual(BedStrand.none, dot.region.strand);
-    try std.testing.expectEqual(BedStrand.invalid, invalid.region.strand);
-}
-
-test "parseBedLine skips comments and empty lines" {
-    try std.testing.expectEqual(ParseResult.skip, try parseBedLine("", 1));
-    try std.testing.expectEqual(ParseResult.skip, try parseBedLine("# comment", 2));
-    try std.testing.expectEqual(ParseResult.skip, try parseBedLine("track name=foo", 3));
-    try std.testing.expectEqual(ParseResult.skip, try parseBedLine("browser position chr1:1-10", 4));
-}
-
-test "parseBedLine preserves chromosome names that resemble directives" {
-    const cases = [_][]const u8{
-        "track1\t0\t10",
-        "browser1\t0\t10",
-        "track\t0\t10",
-        "browser\t0\t10",
-    };
-
-    for (cases) |line| {
-        const parsed = try parseBedLine(line, 1);
-
-        try std.testing.expectEqualStrings(line[0..std.mem.indexOfScalar(u8, line, '\t').?], parsed.region.chrom);
-    }
-}
-
-test "parseBedLine trims CRLF line endings" {
-    const parsed = try parseBedLine("chr2\t5\t9\r", 7);
-    try std.testing.expectEqualStrings("chr2", parsed.region.chrom);
-    try std.testing.expectEqual(@as(u64, 6), parsed.region.start1Based());
-    try std.testing.expectEqual(@as(u64, 9), parsed.region.end1BasedInclusive());
-}
-
-test "parseBedLine rejects malformed coordinates" {
-    try std.testing.expectError(error.InvalidStart, parseBedLine("chr1\t-1\t10", 1));
-    try std.testing.expectError(error.InvalidEnd, parseBedLine("chr1\t0\tfoo", 1));
-    try std.testing.expectError(error.EmptyInterval, parseBedLine("chr1\t10\t10", 1));
-    try std.testing.expectError(error.EmptyInterval, parseBedLine("chr1\t10\t9", 1));
-}
-
-test "parseBedLine rejects missing required columns" {
-    try std.testing.expectError(error.MissingStart, parseBedLine("chr1", 1));
-    try std.testing.expectError(error.MissingEnd, parseBedLine("chr1\t0", 1));
-    try std.testing.expectError(error.MissingChrom, parseBedLine("\t0\t10", 1));
 }

--- a/src/bed_parser.zig
+++ b/src/bed_parser.zig
@@ -42,19 +42,25 @@ pub const ParseResult = union(enum) {
 };
 
 fn parseStrand(field: []const u8) BedStrand {
-    if (field.len == 0 or std.mem.eql(u8, field, ".")) return .none;
-    if (std.mem.eql(u8, field, "+")) return .plus;
-    if (std.mem.eql(u8, field, "-")) return .minus;
-    return .invalid;
+    if (field.len == 0) return .none;
+    if (field.len != 1) return .invalid;
+
+    return switch (field[0]) {
+        '+' => .plus,
+        '-' => .minus,
+        '.' => .none,
+        else => .invalid,
+    };
 }
 
+/// Parses one BED line. Returned region slices borrow from `line`.
 pub fn parseBedLine(line: []const u8, line_number: usize) ParseError!ParseResult {
     const trimmed = if (line.len > 0 and line[line.len - 1] == '\r') line[0 .. line.len - 1] else line;
 
     if (trimmed.len == 0) return .skip;
     if (trimmed[0] == '#') return .skip;
-    if (std.mem.startsWith(u8, trimmed, "track")) return .skip;
-    if (std.mem.startsWith(u8, trimmed, "browser")) return .skip;
+    if (std.mem.eql(u8, trimmed, "track") or std.mem.startsWith(u8, trimmed, "track ")) return .skip;
+    if (std.mem.eql(u8, trimmed, "browser") or std.mem.startsWith(u8, trimmed, "browser ")) return .skip;
 
     var fields = std.mem.splitScalar(u8, trimmed, '\t');
 
@@ -120,6 +126,21 @@ test "parseBedLine skips comments and empty lines" {
     try std.testing.expectEqual(ParseResult.skip, try parseBedLine("# comment", 2));
     try std.testing.expectEqual(ParseResult.skip, try parseBedLine("track name=foo", 3));
     try std.testing.expectEqual(ParseResult.skip, try parseBedLine("browser position chr1:1-10", 4));
+}
+
+test "parseBedLine preserves chromosome names that resemble directives" {
+    const cases = [_][]const u8{
+        "track1\t0\t10",
+        "browser1\t0\t10",
+        "track\t0\t10",
+        "browser\t0\t10",
+    };
+
+    for (cases) |line| {
+        const parsed = try parseBedLine(line, 1);
+
+        try std.testing.expectEqualStrings(line[0..std.mem.indexOfScalar(u8, line, '\t').?], parsed.region.chrom);
+    }
 }
 
 test "parseBedLine trims CRLF line endings" {

--- a/src/complement.zig
+++ b/src/complement.zig
@@ -1,6 +1,4 @@
-//! IUPAC complement and reverse-complement lookup tables (comptime 256-byte maps).
-//!
-//! Used by GET transforms (`--rc`, `--complement-only`, `--reverse-only`).
+//! IUPAC byte complementation for GET transforms.
 
 const std = @import("std");
 
@@ -36,7 +34,7 @@ fn buildComplementTable() [256]u8 {
 
 const IUPAC_COMPLEMENT_TABLE: [256]u8 = buildComplementTable();
 
-/// Return the IUPAC complement for one base.
+/// Returns the IUPAC complement for one byte.
 /// Unknown bytes pass through unchanged.
 pub fn complement(byte: u8) u8 {
     return IUPAC_COMPLEMENT_TABLE[byte];
@@ -46,8 +44,7 @@ pub fn complement(byte: u8) u8 {
 pub fn complementInto(dst: []u8, src: []const u8) void {
     std.debug.assert(dst.len == src.len);
     var i: usize = 0;
-    // Process 32-byte chunks with a table lookup per lane (no branch on base).
-    while (i + 32 <= src.len) : (i += 32) {
+    while (src.len - i >= 32) : (i += 32) {
         inline for (0..32) |j| {
             dst[i + j] = IUPAC_COMPLEMENT_TABLE[src[i + j]];
         }
@@ -57,22 +54,10 @@ pub fn complementInto(dst: []u8, src: []const u8) void {
     }
 }
 
-test "complement handles standard bases" {
-    try std.testing.expectEqual(@as(u8, 'T'), complement('A'));
-    try std.testing.expectEqual(@as(u8, 'A'), complement('T'));
-    try std.testing.expectEqual(@as(u8, 'G'), complement('C'));
-    try std.testing.expectEqual(@as(u8, 'C'), complement('G'));
-}
-
-test "complement handles lowercase bases" {
-    try std.testing.expectEqual(@as(u8, 't'), complement('a'));
-    try std.testing.expectEqual(@as(u8, 'a'), complement('t'));
-    try std.testing.expectEqual(@as(u8, 'g'), complement('c'));
-    try std.testing.expectEqual(@as(u8, 'c'), complement('g'));
-}
-
-test "complement handles IUPAC ambiguity codes" {
+test "[unit] - [complement]: maps IUPAC symbols and preserves other bytes" {
     const pairs = [_][2]u8{
+        .{ 'A', 'T' },
+        .{ 'C', 'G' },
         .{ 'R', 'Y' },
         .{ 'W', 'W' },
         .{ 'S', 'S' },
@@ -88,25 +73,26 @@ test "complement handles IUPAC ambiguity codes" {
         try std.testing.expectEqual(std.ascii.toLower(pair[1]), complement(std.ascii.toLower(pair[0])));
         try std.testing.expectEqual(std.ascii.toLower(pair[0]), complement(std.ascii.toLower(pair[1])));
     }
-}
-
-test "complement maps uracil to adenine" {
     try std.testing.expectEqual(@as(u8, 'A'), complement('U'));
     try std.testing.expectEqual(@as(u8, 'a'), complement('u'));
+
+    for ([_]u8{ 0, '-', 'X', 'x', 0xff }) |byte| {
+        try std.testing.expectEqual(byte, complement(byte));
+    }
 }
 
-test "complement leaves unknown bytes unchanged" {
-    try std.testing.expectEqual(@as(u8, '-'), complement('-'));
-    try std.testing.expectEqual(@as(u8, 'X'), complement('X'));
-    try std.testing.expectEqual(@as(u8, 'x'), complement('x'));
-}
+test "[property] - [complementInto]: matches scalar mapping across chunk boundaries" {
+    const alphabet = "ACGTRYSWKMBDHVNacgtryswkmbdhvnUu-Xx";
+    var src: [97]u8 = undefined;
+    for (&src, 0..) |*byte, i| byte.* = alphabet[i % alphabet.len];
 
-test "complementInto handles an unrolled chunk and tail" {
-    const src: [33]u8 = @splat('A');
-    const expected: [33]u8 = @splat('T');
-    var dst: [33]u8 = undefined;
+    for (0..src.len + 1) |len| {
+        var dst: [src.len]u8 = @splat(0xff);
+        complementInto(dst[0..len], src[0..len]);
 
-    complementInto(&dst, &src);
-
-    try std.testing.expectEqualSlices(u8, &expected, &dst);
+        for (src[0..len], dst[0..len]) |input, actual| {
+            try std.testing.expectEqual(complement(input), actual);
+        }
+        if (len < dst.len) try std.testing.expectEqual(@as(u8, 0xff), dst[len]);
+    }
 }

--- a/src/complement.zig
+++ b/src/complement.zig
@@ -34,26 +34,26 @@ fn buildComplementTable() [256]u8 {
     return table;
 }
 
-pub const iupac_complement_table: [256]u8 = buildComplementTable();
+const IUPAC_COMPLEMENT_TABLE: [256]u8 = buildComplementTable();
 
 /// Return the IUPAC complement for one base.
-/// Unknown bytes pass through unchanged so headers and non-sequence bytes are not mangled.
+/// Unknown bytes pass through unchanged.
 pub fn complement(byte: u8) u8 {
-    return iupac_complement_table[byte];
+    return IUPAC_COMPLEMENT_TABLE[byte];
 }
 
-/// Write the IUPAC complement of `src` into `dst` (same length).
+/// Write the IUPAC complement of `src` into `dst`; asserts equal lengths.
 pub fn complementInto(dst: []u8, src: []const u8) void {
     std.debug.assert(dst.len == src.len);
     var i: usize = 0;
     // Process 32-byte chunks with a table lookup per lane (no branch on base).
     while (i + 32 <= src.len) : (i += 32) {
         inline for (0..32) |j| {
-            dst[i + j] = iupac_complement_table[src[i + j]];
+            dst[i + j] = IUPAC_COMPLEMENT_TABLE[src[i + j]];
         }
     }
     while (i < src.len) : (i += 1) {
-        dst[i] = iupac_complement_table[src[i]];
+        dst[i] = IUPAC_COMPLEMENT_TABLE[src[i]];
     }
 }
 
@@ -99,4 +99,14 @@ test "complement leaves unknown bytes unchanged" {
     try std.testing.expectEqual(@as(u8, '-'), complement('-'));
     try std.testing.expectEqual(@as(u8, 'X'), complement('X'));
     try std.testing.expectEqual(@as(u8, 'x'), complement('x'));
+}
+
+test "complementInto handles an unrolled chunk and tail" {
+    const src: [33]u8 = @splat('A');
+    const expected: [33]u8 = @splat('T');
+    var dst: [33]u8 = undefined;
+
+    complementInto(&dst, &src);
+
+    try std.testing.expectEqualSlices(u8, &expected, &dst);
 }

--- a/src/getter.zig
+++ b/src/getter.zig
@@ -12,15 +12,16 @@ const stats = @import("stats.zig");
 const LoadedIndex = index_format.LoadedIndex;
 const printErrorAndExit = index_format.printErrorAndExit;
 
-// --- Region parsing ---
-
+/// A borrowed sequence name with an optional 1-based inclusive interval.
+/// `is_full` preserves the distinct header form of a bare name.
 pub const Region = struct {
     name: []const u8,
-    start: u64, // 1-based inclusive
-    end: ?u64, // 1-based inclusive, null = to end of sequence
-    is_full: bool, // true if no :START-END specified
+    start: u64,
+    end: ?u64,
+    is_full: bool,
 };
 
+/// Independent reverse and complement operations composed by toggling each operation.
 pub const Orientation = struct {
     reverse: bool = false,
     complement: bool = false,
@@ -49,6 +50,8 @@ pub const Orientation = struct {
     }
 };
 
+/// GET execution options for one borrowed request source.
+/// Direct callers must supply combinations accepted by the CLI contract.
 pub const GetOptions = struct {
     source: RequestSource,
     honor_strand: bool = false,
@@ -57,6 +60,7 @@ pub const GetOptions = struct {
     annotate_transform: bool = false,
 };
 
+/// Borrowed positional tokens or a names/BED path; a path of `-` selects stdin.
 pub const RequestSource = union(enum) {
     positional: []const []const u8,
     names: []const u8,
@@ -128,14 +132,9 @@ const BatchStats = struct {
     total_bases: u64 = 0,
 };
 
-/// Parse a region string. Handles the Ensembl colon trap by parsing from the right.
-/// Accepted formats:
-///   NAME              full sequence
-///   NAME:START-END    1-based, inclusive
-///   NAME:START-       from START to end
+/// Parses a borrowed name or rightmost `:START-END`/`:START-` suffix.
+/// Invalid or overflowing suffixes remain part of the literal name.
 pub fn parseRegion(input: []const u8) Region {
-    // Only the rightmost colon can start a coordinate suffix. Any earlier suffix
-    // contains that colon, so its coordinate fields cannot both be integers.
     if (std.mem.findScalarLast(u8, input, ':')) |cp| {
         const suffix = input[cp + 1 ..];
 
@@ -149,7 +148,6 @@ pub fn parseRegion(input: []const u8) Region {
         }
     }
 
-    // No valid region suffix found; treat entire input as sequence name
     return Region{
         .name = input,
         .start = 1,
@@ -178,16 +176,15 @@ fn parseRangeSuffix(suffix: []const u8) ?ParsedRange {
     return .{ .start = start, .end = end };
 }
 
-// --- Region resolution ---
-
-/// A validated extraction request with the record geometry needed for bounded reads.
+/// A validated extraction request borrowing its name and non-uniform line table.
+/// Coordinates are 1-based inclusive; `display_end` preserves an unclamped request end.
 pub const ResolvedRegion = struct {
-    name: []const u8, // sequence name for FASTA header
-    start: u64, // 1-based inclusive (validated)
-    display_end: u64, // end value for header (pre-clamp, samtools convention)
-    is_full: bool, // true -> emit ">NAME", false -> emit ">NAME:start-display_end"
+    name: []const u8,
+    start: u64,
+    display_end: u64,
+    is_full: bool,
     seq_offset: u64,
-    num_bases: u64, // number of bases to extract
+    num_bases: u64,
     line_bases: u32,
     line_bytes: u32,
     side_table: []const index_format.SideTableLine,
@@ -196,8 +193,8 @@ pub const ResolvedRegion = struct {
     annotate_transform: bool,
 };
 
-/// Resolve one region string against a loaded index.
-/// Calls `printErrorAndExit` when the name or coordinates are invalid.
+/// Resolves one region against an index and returns slices borrowing the index and input.
+/// Exits the process when the name or coordinates are invalid.
 pub fn resolveRegion(idx: *const LoadedIndex, region_str: []const u8) ResolvedRegion {
     const region = parseRegion(region_str);
 
@@ -224,7 +221,7 @@ fn resolveParsedRequest(
 
     var start = region.start;
     var end = region.end orelse rec.seq_len;
-    const display_end = end; // capture before clamping (samtools keeps unclamped in header)
+    const display_end = end;
 
     if (region.is_full) {
         start = 1;
@@ -241,7 +238,6 @@ fn resolveParsedRequest(
         printErrorAndExit("error: end position must be >= start position\n", .{});
     }
 
-    // Clamp end to seq_len silently (samtools behavior)
     if (end > rec.seq_len) {
         end = rec.seq_len;
     }
@@ -313,7 +309,7 @@ fn fastaSource(idx: *const LoadedIndex) FastaSource {
     return .{ .io = idx.io, .file = idx.fasta_file, .size = idx.fasta_size };
 }
 
-/// Writes a resolved region with standard 60-base wrapping.
+/// Resolves and writes one region with 60-base wrapping, exiting on any failure.
 pub fn extractRegion(idx: *const LoadedIndex, region_str: []const u8, writer: anytype) void {
     const resolved = resolveRegion(idx, region_str);
     var input_buffer: [FASTA_INPUT_BUFFER_BYTES]u8 = undefined;
@@ -1122,8 +1118,8 @@ fn processRequestPath(
     return processRequestReader(allocator, idx, &file_reader.interface, source, name_reservation, annotate_transform, writer, fasta_source);
 }
 
-// --- Public entry point ---
-
+/// Runs one GET source, writing FASTA to stdout and an optional summary to stderr.
+/// All failures terminate the process through the command diagnostic path.
 pub fn runGetWithOptions(
     backing_allocator: std.mem.Allocator,
     io: std.Io,
@@ -1209,14 +1205,14 @@ pub fn runGetWithOptions(
     }
 }
 
-test "summary writing fails when the destination is full" {
+test "[failure] - [get summary]: propagates a full destination" {
     var buffer: [1]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buffer);
 
     try std.testing.expectError(error.WriteFailed, writeSummary(&writer, 1, 1, 1));
 }
 
-test "shared disk spans require overlap or adjacency in either order" {
+test "[unit] - [get read grouping]: accepts overlap and adjacency in either order" {
     try std.testing.expect(spansOverlapOrTouch(10, 20, 20, 30));
     try std.testing.expect(spansOverlapOrTouch(20, 30, 10, 20));
     try std.testing.expect(spansOverlapOrTouch(10, 20, 15, 25));
@@ -1225,7 +1221,7 @@ test "shared disk spans require overlap or adjacency in either order" {
     try std.testing.expect(!spansOverlapOrTouch(21, 30, 10, 20));
 }
 
-test "request workspace reuses consecutive names" {
+test "[unit] - [get request workspace]: reuses consecutive names" {
     var workspace = RequestWorkspace.init(std.testing.allocator);
     defer workspace.deinit(std.testing.allocator);
 
@@ -1240,7 +1236,7 @@ test "request workspace reuses consecutive names" {
     try std.testing.expectEqualStrings("seq2", workspace.requests.items[2].parsed(workspace.names.items).region.name);
 }
 
-test "request workspace includes the name that crosses its byte target" {
+test "[edge] - [get request workspace]: retains the name crossing its byte target" {
     var workspace = RequestWorkspace.init(std.testing.allocator);
     defer workspace.deinit(std.testing.allocator);
     const name = try std.testing.allocator.alloc(u8, MAX_REQUEST_NAME_BYTES);
@@ -1261,7 +1257,7 @@ test "request workspace includes the name that crosses its byte target" {
     try std.testing.expect(workspace.names.capacity <= MAX_ACTIVE_NAME_BYTES);
 }
 
-test "processRequestReader handles names line endings and final line" {
+test "[unit] - [get names reader]: handles line endings and a final unterminated line" {
     const test_io = std.testing.io;
     var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
     defer idx.deinit();
@@ -1288,7 +1284,7 @@ test "processRequestReader handles names line endings and final line" {
     );
 }
 
-test "processRequestReader resets names at the request-count boundary" {
+test "[edge] - [get names reader]: resets storage at the request-count boundary" {
     const test_io = std.testing.io;
     var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
     defer idx.deinit();
@@ -1319,7 +1315,7 @@ test "processRequestReader resets names at the request-count boundary" {
     try std.testing.expectEqualStrings(one_output, writer.written()[writer.written().len - one_output.len ..]);
 }
 
-test "processRequestReader streams BED rows in source order" {
+test "[unit] - [get BED reader]: streams rows in source order" {
     const test_io = std.testing.io;
     var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
     defer idx.deinit();
@@ -1353,7 +1349,7 @@ test "processRequestReader streams BED rows in source order" {
     );
 }
 
-test "processRequestReader preserves output at BED request boundaries" {
+test "[edge] - [get BED reader]: preserves output across request-batch boundaries" {
     const test_io = std.testing.io;
     var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
     defer idx.deinit();
@@ -1398,90 +1394,4 @@ test "processRequestReader preserves output at BED request boundaries" {
         try std.testing.expectEqual(expected_bases, result.total_bases);
         try std.testing.expectEqualStrings(expected.written(), output.written());
     }
-}
-
-test "parseRegion matches exhaustive backward-scan reference" {
-    const Reference = struct {
-        fn findLastColon(input: []const u8, end: usize) ?usize {
-            var i = end;
-            while (i > 0) {
-                i -= 1;
-                if (input[i] == ':') return i;
-            }
-            return null;
-        }
-
-        fn parse(input: []const u8) Region {
-            var search_end = input.len;
-            while (findLastColon(input, search_end)) |colon_pos| {
-                if (parseRangeSuffix(input[colon_pos + 1 ..])) |range| {
-                    return .{
-                        .name = input[0..colon_pos],
-                        .start = range.start,
-                        .end = range.end,
-                        .is_full = false,
-                    };
-                }
-                search_end = colon_pos;
-            }
-            return .{ .name = input, .start = 1, .end = null, .is_full = true };
-        }
-    };
-
-    const alphabet = "a:0-1";
-    var input: [7]u8 = undefined;
-    var combinations: usize = 1;
-    var tested: usize = 0;
-    for (1..input.len + 1) |length| {
-        combinations *= alphabet.len;
-        for (0..combinations) |encoded| {
-            var value = encoded;
-            for (input[0..length]) |*byte| {
-                byte.* = alphabet[value % alphabet.len];
-                value /= alphabet.len;
-            }
-
-            const expected = Reference.parse(input[0..length]);
-            const actual = parseRegion(input[0..length]);
-            try std.testing.expectEqualStrings(expected.name, actual.name);
-            try std.testing.expectEqual(expected.start, actual.start);
-            try std.testing.expectEqual(expected.end, actual.end);
-            try std.testing.expectEqual(expected.is_full, actual.is_full);
-            tested += 1;
-        }
-    }
-    try std.testing.expectEqual(@as(usize, 97_655), tested);
-}
-
-test "parseRegion handles coordinate overflow at the rightmost colon" {
-    const max = parseRegion("name:18446744073709551615-18446744073709551615");
-    try std.testing.expectEqualStrings("name", max.name);
-    try std.testing.expectEqual(@as(u64, std.math.maxInt(u64)), max.start);
-    try std.testing.expectEqual(@as(?u64, std.math.maxInt(u64)), max.end);
-    try std.testing.expect(!max.is_full);
-
-    const full_names = [_][]const u8{
-        "name:18446744073709551616-1",
-        "name:1-18446744073709551616",
-        "name:1-2:bad",
-        "name:1-2:18446744073709551616-1",
-    };
-    for (full_names) |name| {
-        const region = parseRegion(name);
-        try std.testing.expectEqualStrings(name, region.name);
-        try std.testing.expect(region.is_full);
-    }
-}
-
-test "orientation compose behaves like transform composition" {
-    const minus_strand = Orientation.reverseComplement();
-    const global_rc = Orientation.reverseComplement();
-    const global_reverse = Orientation.reverseOnly();
-    const global_complement = Orientation.complementOnly();
-
-    try std.testing.expect(minus_strand.compose(global_rc).isIdentity());
-    try std.testing.expectEqual(true, minus_strand.compose(global_reverse).complement);
-    try std.testing.expectEqual(false, minus_strand.compose(global_reverse).reverse);
-    try std.testing.expectEqual(true, minus_strand.compose(global_complement).reverse);
-    try std.testing.expectEqual(false, minus_strand.compose(global_complement).complement);
 }

--- a/src/getter.zig
+++ b/src/getter.zig
@@ -136,19 +136,7 @@ const BatchStats = struct {
 pub fn parseRegion(input: []const u8) Region {
     // Only the rightmost colon can start a coordinate suffix. Any earlier suffix
     // contains that colon, so its coordinate fields cannot both be integers.
-    var colon_pos: ?usize = null;
-    {
-        var i: usize = input.len;
-        while (i > 0) {
-            i -= 1;
-            if (input[i] == ':') {
-                colon_pos = i;
-                break;
-            }
-        }
-    }
-
-    if (colon_pos) |cp| {
+    if (std.mem.findScalarLast(u8, input, ':')) |cp| {
         const suffix = input[cp + 1 ..];
 
         if (parseRangeSuffix(suffix)) |range| {
@@ -176,21 +164,15 @@ const ParsedRange = struct {
 };
 
 fn parseRangeSuffix(suffix: []const u8) ?ParsedRange {
-    // Expect: START-END or START-
-    // Find the '-' separator
-    const dash_pos = std.mem.indexOfScalar(u8, suffix, '-') orelse return null;
+    const dash_pos = std.mem.findScalar(u8, suffix, '-') orelse return null;
 
     const start_str = suffix[0..dash_pos];
     const end_str = suffix[dash_pos + 1 ..];
 
-    // START must be a valid positive integer
     if (start_str.len == 0) return null;
     const start = std.fmt.parseInt(u64, start_str, 10) catch return null;
 
-    if (end_str.len == 0) {
-        // NAME:START- form (to end of sequence)
-        return .{ .start = start, .end = null };
-    }
+    if (end_str.len == 0) return .{ .start = start, .end = null };
 
     const end = std.fmt.parseInt(u64, end_str, 10) catch return null;
     return .{ .start = start, .end = end };

--- a/src/getter.zig
+++ b/src/getter.zig
@@ -9,13 +9,10 @@ const bed_parser = @import("bed_parser.zig");
 const index_format = @import("index_format.zig");
 const stats = @import("stats.zig");
 
-const IndexRecord = index_format.IndexRecord;
 const LoadedIndex = index_format.LoadedIndex;
 const printErrorAndExit = index_format.printErrorAndExit;
 
-// ============================================================================
-// Region parsing
-// ============================================================================
+// --- Region parsing ---
 
 pub const Region = struct {
     name: []const u8,
@@ -87,7 +84,6 @@ const OwnedRequest = struct {
     name_len: u16,
     start: u64,
     end: u64,
-    is_full: bool,
     orientation: Orientation,
 
     fn parsed(self: OwnedRequest, names: []const u8) ParsedRequest {
@@ -98,7 +94,7 @@ const OwnedRequest = struct {
                 .name = names[name_offset..name_end],
                 .start = self.start,
                 .end = if (self.end == 0) null else self.end,
-                .is_full = self.is_full,
+                .is_full = self.end == 0,
             },
             .orientation = self.orientation,
         };
@@ -174,12 +170,12 @@ pub fn parseRegion(input: []const u8) Region {
     };
 }
 
-const RangeParsed = struct {
+const ParsedRange = struct {
     start: u64,
     end: ?u64,
 };
 
-fn parseRangeSuffix(suffix: []const u8) ?RangeParsed {
+fn parseRangeSuffix(suffix: []const u8) ?ParsedRange {
     // Expect: START-END or START-
     // Find the '-' separator
     const dash_pos = std.mem.indexOfScalar(u8, suffix, '-') orelse return null;
@@ -193,41 +189,34 @@ fn parseRangeSuffix(suffix: []const u8) ?RangeParsed {
 
     if (end_str.len == 0) {
         // NAME:START- form (to end of sequence)
-        return RangeParsed{ .start = start, .end = null };
+        return .{ .start = start, .end = null };
     }
 
     const end = std.fmt.parseInt(u64, end_str, 10) catch return null;
-    return RangeParsed{ .start = start, .end = end };
+    return .{ .start = start, .end = end };
 }
 
-// ============================================================================
-// Region resolution
-// ============================================================================
+// --- Region resolution ---
 
-/// A fully resolved, validated extraction request.
-/// Byte offset and length are pre-computed; no further index lookups are required.
+/// A validated extraction request with the record geometry needed for bounded reads.
 pub const ResolvedRegion = struct {
     name: []const u8, // sequence name for FASTA header
     start: u64, // 1-based inclusive (validated)
     display_end: u64, // end value for header (pre-clamp, samtools convention)
     is_full: bool, // true -> emit ">NAME", false -> emit ">NAME:start-display_end"
-    start_byte: u64, // absolute FASTA byte offset of the first base
     seq_offset: u64,
     num_bases: u64, // number of bases to extract
     line_bases: u32,
     line_bytes: u32,
     side_table: []const index_format.SideTableLine,
-    record_index: usize = 0,
-    sequence_type: ?stats.SequenceType = null,
+    record_index: usize,
     orientation: Orientation,
     annotate_transform: bool,
-    original_index: usize, // position in CLI argument list (preserves output order)
 };
 
 /// Resolve one region string against a loaded index.
-/// Validates coordinates and pre-computes the O(1) byte offset.
-/// Calls printErrorAndExit on any error (sequence not found, bad coordinates).
-pub fn resolveRegion(idx: *const LoadedIndex, region_str: []const u8, original_index: usize) ResolvedRegion {
+/// Calls `printErrorAndExit` when the name or coordinates are invalid.
+pub fn resolveRegion(idx: *const LoadedIndex, region_str: []const u8) ResolvedRegion {
     const region = parseRegion(region_str);
 
     const rec_idx = idx.lookupName(region.name) orelse {
@@ -238,7 +227,6 @@ pub fn resolveRegion(idx: *const LoadedIndex, region_str: []const u8, original_i
         idx,
         .{ .region = region, .orientation = .{} },
         rec_idx,
-        original_index,
         false,
     );
 }
@@ -247,7 +235,6 @@ fn resolveParsedRequest(
     idx: *const LoadedIndex,
     request: ParsedRequest,
     rec_idx: usize,
-    original_index: usize,
     annotate_transform: bool,
 ) ResolvedRegion {
     const rec = idx.records[rec_idx];
@@ -280,14 +267,12 @@ fn resolveParsedRequest(
     const num_bases = end - start + 1;
 
     const side_table = idx.sideTableLines(rec);
-    const start_byte = byteOffsetForBase(idx.fasta_data, rec, side_table, start - 1);
 
     return ResolvedRegion{
         .name = region.name,
         .start = start,
         .display_end = display_end,
         .is_full = region.is_full,
-        .start_byte = start_byte,
         .seq_offset = rec.seq_offset,
         .num_bases = num_bases,
         .line_bases = rec.line_bases,
@@ -296,52 +281,7 @@ fn resolveParsedRequest(
         .record_index = rec_idx,
         .orientation = request.orientation,
         .annotate_transform = annotate_transform,
-        .original_index = original_index,
     };
-}
-
-fn byteOffsetForBase(
-    fasta: []const u8,
-    rec: IndexRecord,
-    side_table: []const index_format.SideTableLine,
-    base_index: u64,
-) u64 {
-    if (side_table.len == 0) {
-        const line_number = base_index / rec.line_bases;
-        const column = base_index % rec.line_bases;
-        return rec.seq_offset + (line_number * rec.line_bytes) + column;
-    }
-
-    var lo: usize = 0;
-    var hi: usize = side_table.len;
-    while (lo < hi) {
-        const mid = lo + (hi - lo) / 2;
-        if (side_table[mid].base_start <= base_index) {
-            lo = mid + 1;
-        } else {
-            hi = mid;
-        }
-    }
-    const line_idx = if (lo == 0) 0 else lo - 1;
-    const line = side_table[line_idx];
-    const column = base_index - line.base_start;
-
-    if (fasta.len == 0) {
-        return std.math.add(u64, line.byte_offset, column) catch {
-            printErrorAndExit("error: corrupt non-uniform index side table\n", .{});
-        };
-    }
-
-    var seen: u64 = 0;
-    var pos: usize = @intCast(line.byte_offset);
-    const end = @min(fasta.len, pos + @as(usize, @intCast(line.line_bytes)));
-    while (pos < end) : (pos += 1) {
-        if (fasta[pos] <= ' ') continue;
-        if (seen == column) return @intCast(pos);
-        seen += 1;
-    }
-
-    printErrorAndExit("error: corrupt non-uniform index side table\n", .{});
 }
 
 fn detectRegionType(source: FastaSource, resolved: ResolvedRegion) stats.SequenceType {
@@ -353,7 +293,7 @@ fn detectRegionType(source: FastaSource, resolved: ResolvedRegion) stats.Sequenc
     var counts = [_]u64{0} ** 256;
     var total: u64 = 0;
     var skip = span.leading_bases;
-    var input: [fasta_input_buffer_bytes]u8 = undefined;
+    var input: [FASTA_INPUT_BUFFER_BYTES]u8 = undefined;
     var offset = span.start;
 
     while (offset < span.end and total < resolved.num_bases) {
@@ -379,9 +319,7 @@ fn detectRegionType(source: FastaSource, resolved: ResolvedRegion) stats.Sequenc
     return stats.detectType(&counts, total);
 }
 
-// ============================================================================
-// Sequence emission
-// ============================================================================
+// --- Sequence emission ---
 
 const FastaSource = struct {
     io: std.Io,
@@ -389,20 +327,20 @@ const FastaSource = struct {
     size: u64,
 };
 
-/// Writes a resolved region with standard 60-base wrapping.
-pub fn extractRegion(idx: *const LoadedIndex, region_str: []const u8, writer: anytype) void {
-    const resolved = resolveRegion(idx, region_str, 0);
-    var input_buffer: [fasta_input_buffer_bytes]u8 = undefined;
-    var output_buffer: [region_output_buffer_bytes]u8 = undefined;
-    emitRegion(resolved, .{
-        .io = idx.io,
-        .file = idx.fasta_file,
-        .size = idx.fasta_size,
-    }, &input_buffer, &output_buffer, writer);
+fn fastaSource(idx: *const LoadedIndex) FastaSource {
+    return .{ .io = idx.io, .file = idx.fasta_file, .size = idx.fasta_size };
 }
 
-const fasta_input_buffer_bytes: usize = 256 * 1024;
-const region_output_buffer_bytes: usize = 64 * 1024;
+/// Writes a resolved region with standard 60-base wrapping.
+pub fn extractRegion(idx: *const LoadedIndex, region_str: []const u8, writer: anytype) void {
+    const resolved = resolveRegion(idx, region_str);
+    var input_buffer: [FASTA_INPUT_BUFFER_BYTES]u8 = undefined;
+    var output_buffer: [REGION_OUTPUT_BUFFER_BYTES]u8 = undefined;
+    emitRegion(resolved, fastaSource(idx), &input_buffer, &output_buffer, writer);
+}
+
+const FASTA_INPUT_BUFFER_BYTES: usize = 256 * 1024;
+const REGION_OUTPUT_BUFFER_BYTES: usize = 64 * 1024;
 
 const DiskSpan = struct {
     start: u64,
@@ -810,8 +748,8 @@ fn emitResolvedBatch(
     writer: anytype,
 ) u64 {
     var total_bases: u64 = 0;
-    var shared: [fasta_input_buffer_bytes]u8 = undefined;
-    var output_buffer: [region_output_buffer_bytes]u8 = undefined;
+    var shared: [FASTA_INPUT_BUFFER_BYTES]u8 = undefined;
+    var output_buffer: [REGION_OUTPUT_BUFFER_BYTES]u8 = undefined;
     var i: usize = 0;
 
     while (i < resolved.len) {
@@ -841,7 +779,7 @@ fn emitResolvedBatch(
             shared_last_base = @max(shared_last_base, next_last_base);
         }
 
-        if (group_end > i + 1 or shared_end - shared_start <= shared.len) {
+        if (shared_end - shared_start <= shared.len) {
             if (shared_end > source.size) printErrorAndExit("error: read past end of FASTA\n", .{});
             const wanted: usize = @intCast(shared_end - shared_start);
             const got = std.Io.File.readPositionalAll(source.file, source.io, shared[0..wanted], shared_start) catch {
@@ -915,7 +853,6 @@ fn appendOwnedRequest(
     name: []const u8,
     start: u64,
     end: u64,
-    is_full: bool,
     orientation: Orientation,
 ) void {
     const owned_name = ownRequestName(allocator, workspace, name);
@@ -924,7 +861,6 @@ fn appendOwnedRequest(
         .name_len = owned_name.len,
         .start = start,
         .end = end,
-        .is_full = is_full,
         .orientation = orientation,
     }) catch {
         printErrorAndExit("error: out of memory\n", .{});
@@ -966,7 +902,6 @@ fn appendBedLineRequest(
                 region.chrom,
                 region.start1Based(),
                 region.end1BasedInclusive(),
-                false,
                 (if (honor_strand and region.strand == .minus) Orientation.reverseComplement() else Orientation{}).compose(global_orientation),
             );
         },
@@ -988,10 +923,15 @@ fn appendNamesLine(
             .{ line_number, MAX_REQUEST_NAME_BYTES },
         );
     }
-    appendOwnedRequest(allocator, workspace, name, 1, 0, true, orientation);
+    appendOwnedRequest(allocator, workspace, name, 1, 0, orientation);
 }
 
-fn appendCliRequests(requests: *std.ArrayList(ParsedRequest), region_strs: []const []const u8, orientation: Orientation, allocator: std.mem.Allocator) void {
+fn appendCliRequests(
+    allocator: std.mem.Allocator,
+    requests: *std.ArrayList(ParsedRequest),
+    region_strs: []const []const u8,
+    orientation: Orientation,
+) void {
     for (region_strs) |region_str| {
         requests.append(allocator, .{
             .region = parseRegion(region_str),
@@ -1010,8 +950,8 @@ fn writeSummary(writer: *std.Io.Writer, region_count: usize, total_bases: u64, e
 }
 
 fn processParsedRequests(
-    idx: *index_format.LoadedIndex,
     allocator: std.mem.Allocator,
+    idx: *index_format.LoadedIndex,
     request_entries: anytype,
     active_names: []const u8,
     annotate_transform: bool,
@@ -1046,24 +986,23 @@ fn processParsedRequests(
 
         last_name = request.region.name;
         last_rec_idx = rec_idx;
-        resolved[i] = resolveParsedRequest(idx, request, rec_idx, i, annotate_transform);
+        resolved[i] = resolveParsedRequest(idx, request, rec_idx, annotate_transform);
 
         if (request.orientation.complement) {
             const rec_type = if (last_typed_rec_idx == rec_idx)
                 last_type
             else blk: {
                 var sample = resolved[i];
-                sample.num_bases = @min(sample.num_bases, stats.get_type_sample_bases);
+                sample.num_bases = @min(sample.num_bases, stats.GET_TYPE_SAMPLE_BASES);
                 const detected = detectRegionType(source, sample);
                 last_typed_rec_idx = rec_idx;
                 last_type = detected;
                 break :blk detected;
             };
-            resolved[i].sequence_type = rec_type;
             if (rec_type == .protein) {
                 printErrorAndExit(
                     "error: reverse complement is not defined for protein sequences: {s} (classified from up to {d} bases)\n",
-                    .{ request.region.name, stats.get_type_sample_bases },
+                    .{ request.region.name, stats.GET_TYPE_SAMPLE_BASES },
                 );
             }
         }
@@ -1146,8 +1085,8 @@ fn processRequestReader(
         if (workspace.requests.items.len == 0) break;
 
         const batch = processParsedRequests(
-            idx,
             workspace.scratch.allocator(),
+            idx,
             workspace.requests.items,
             workspace.names.items,
             annotate_transform,
@@ -1201,25 +1140,27 @@ fn processRequestPath(
     return processRequestReader(allocator, idx, &file_reader.interface, source, name_reservation, annotate_transform, writer, fasta_source);
 }
 
-// ============================================================================
-// Public entry point
-// ============================================================================
+// --- Public entry point ---
 
-pub fn runGetWithOptions(io: std.Io, fasta_path: []const u8, options: GetOptions) void {
+pub fn runGetWithOptions(
+    backing_allocator: std.mem.Allocator,
+    io: std.Io,
+    fasta_path: []const u8,
+    options: GetOptions,
+) void {
     const start_ns = if (options.summary) monotonicNs(io) else 0;
 
-    var input_arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    var input_arena = std.heap.ArenaAllocator.init(backing_allocator);
     defer input_arena.deinit();
     const allocator = input_arena.allocator();
 
     var requests = std.ArrayList(ParsedRequest).empty;
-    defer requests.deinit(allocator);
 
     // Positional requests are known before loading, so `.fai` retains only their
     // first matching records. Names and BED still require the complete lookup map.
     const load_mode: index_format.LoadMode = switch (options.source) {
         .positional => |region_strs| blk: {
-            appendCliRequests(&requests, region_strs, options.orientation, allocator);
+            appendCliRequests(allocator, &requests, region_strs, options.orientation);
             const names = allocator.alloc([]const u8, requests.items.len) catch {
                 printErrorAndExit("error: out of memory\n", .{});
             };
@@ -1230,59 +1171,41 @@ pub fn runGetWithOptions(io: std.Io, fasta_path: []const u8, options: GetOptions
         },
         .names, .bed => .lookup_full_map,
     };
-    var idx = index_format.loadIndexForGet(io, fasta_path, load_mode);
-    defer idx.deinit(io);
+    var idx = index_format.loadIndexForGet(backing_allocator, io, fasta_path, load_mode);
+    defer idx.deinit();
 
-    const fasta_source = FastaSource{
-        .io = io,
-        .file = idx.fasta_file,
-        .size = idx.fasta_size,
-    };
+    const fasta_source = fastaSource(&idx);
 
     var out_buf: [65536]u8 = undefined;
     var stdout_fw = std.Io.File.Writer.initStreaming(.stdout(), io, &out_buf);
     const writer = &stdout_fw.interface;
 
-    var totals = BatchStats{};
-
-    switch (options.source) {
-        .positional => {
-            const batch = processParsedRequests(&idx, allocator, requests.items, &.{}, options.annotate_transform, writer, fasta_source);
-            totals.region_count += batch.region_count;
-            totals.total_bases += batch.total_bases;
-        },
-        .names => |path| {
-            const batch = processRequestPath(
-                std.heap.page_allocator,
-                io,
-                &idx,
-                path,
-                .{ .names = options.orientation },
-                options.annotate_transform,
-                writer,
-                fasta_source,
-            );
-            totals.region_count += batch.region_count;
-            totals.total_bases += batch.total_bases;
-        },
-        .bed => |path| {
-            const batch = processRequestPath(
-                std.heap.page_allocator,
-                io,
-                &idx,
-                path,
-                .{ .bed = .{
-                    .honor_strand = options.honor_strand,
-                    .global_orientation = options.orientation,
-                } },
-                options.annotate_transform,
-                writer,
-                fasta_source,
-            );
-            totals.region_count += batch.region_count;
-            totals.total_bases += batch.total_bases;
-        },
-    }
+    const totals = switch (options.source) {
+        .positional => processParsedRequests(allocator, &idx, requests.items, &.{}, options.annotate_transform, writer, fasta_source),
+        .names => |path| processRequestPath(
+            backing_allocator,
+            io,
+            &idx,
+            path,
+            .{ .names = options.orientation },
+            options.annotate_transform,
+            writer,
+            fasta_source,
+        ),
+        .bed => |path| processRequestPath(
+            backing_allocator,
+            io,
+            &idx,
+            path,
+            .{ .bed = .{
+                .honor_strand = options.honor_strand,
+                .global_orientation = options.orientation,
+            } },
+            options.annotate_transform,
+            writer,
+            fasta_source,
+        ),
+    };
 
     if (totals.region_count == 0) {
         printErrorAndExit("error: no regions provided\n", .{});
@@ -1358,8 +1281,8 @@ test "request workspace includes the name that crosses its byte target" {
 
 test "processRequestReader handles names line endings and final line" {
     const test_io = std.testing.io;
-    var idx = index_format.loadIndex(test_io, "tests/data/simple.fasta");
-    defer idx.deinit(test_io);
+    var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
+    defer idx.deinit();
     var reader = std.Io.Reader.fixed("# comment\r\n\r\nseq2\r\nseq1\nseq2");
     var writer = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer writer.deinit();
@@ -1372,11 +1295,11 @@ test "processRequestReader handles names line endings and final line" {
         0,
         false,
         &writer.writer,
-        null,
+        fastaSource(&idx),
     );
 
     try std.testing.expectEqual(@as(usize, 3), result.region_count);
-    try std.testing.expectEqual(@as(u64, 60), result.total_bases);
+    try std.testing.expectEqual(@as(u64, 48), result.total_bases);
     try std.testing.expectEqualStrings(
         ">seq2\nGGGGCCCCAAAA\n>seq1\nACGTACGTACGTACGTACGTACGT\n>seq2\nGGGGCCCCAAAA\n",
         writer.written(),
@@ -1385,8 +1308,8 @@ test "processRequestReader handles names line endings and final line" {
 
 test "processRequestReader resets names at the request-count boundary" {
     const test_io = std.testing.io;
-    var idx = index_format.loadIndex(test_io, "tests/data/simple.fasta");
-    defer idx.deinit(test_io);
+    var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
+    defer idx.deinit();
     var names = std.Io.Writer.Allocating.init(std.testing.allocator);
     defer names.deinit();
     const request_count = NAMES_REQUEST_BATCH_SIZE + 1;
@@ -1403,7 +1326,7 @@ test "processRequestReader resets names at the request-count boundary" {
         0,
         false,
         &writer.writer,
-        null,
+        fastaSource(&idx),
     );
 
     const one_output = ">seq1\nACGTACGTACGTACGTACGTACGT\n";
@@ -1416,8 +1339,8 @@ test "processRequestReader resets names at the request-count boundary" {
 
 test "processRequestReader streams BED rows in source order" {
     const test_io = std.testing.io;
-    var idx = index_format.loadIndex(test_io, "tests/data/simple.fasta");
-    defer idx.deinit(test_io);
+    var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     const bed_data =
         "# comment\r\n" ++
@@ -1437,7 +1360,7 @@ test "processRequestReader streams BED rows in source order" {
         0,
         false,
         &writer.writer,
-        null,
+        fastaSource(&idx),
     );
 
     try std.testing.expectEqual(@as(usize, 3), result.region_count);
@@ -1450,8 +1373,8 @@ test "processRequestReader streams BED rows in source order" {
 
 test "processRequestReader preserves output at BED request boundaries" {
     const test_io = std.testing.io;
-    var idx = index_format.loadIndex(test_io, "tests/data/simple.fasta");
-    defer idx.deinit(test_io);
+    var idx = index_format.loadIndex(std.testing.allocator, test_io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     const counts = [_]usize{
         BED_REQUEST_BATCH_SIZE - 1,
@@ -1485,7 +1408,7 @@ test "processRequestReader preserves output at BED request boundaries" {
             0,
             false,
             &output.writer,
-            null,
+            fastaSource(&idx),
         );
 
         const expected_bases: u64 = count + @as(usize, @intFromBool(count > BED_REQUEST_BATCH_SIZE)) * 4;

--- a/src/getter.zig
+++ b/src/getter.zig
@@ -857,7 +857,7 @@ fn appendBedLineRequest(
     honor_strand: bool,
     global_orientation: Orientation,
 ) void {
-    const parsed = bed_parser.parseBedLine(line, line_number) catch |err| switch (err) {
+    const parsed = bed_parser.parseBedLine(line) catch |err| switch (err) {
         error.MissingChrom => printErrorAndExit("error: invalid BED line {d}: missing chrom\n", .{line_number}),
         error.MissingStart => printErrorAndExit("error: invalid BED line {d}: missing start\n", .{line_number}),
         error.MissingEnd => printErrorAndExit("error: invalid BED line {d}: missing end\n", .{line_number}),
@@ -882,9 +882,9 @@ fn appendBedLineRequest(
                 allocator,
                 workspace,
                 region.chrom,
-                region.start1Based(),
-                region.end1BasedInclusive(),
-                (if (honor_strand and region.strand == .minus) Orientation.reverseComplement() else Orientation{}).compose(global_orientation),
+                region.start_1based,
+                region.end_1based,
+                (if (honor_strand and region.strand == .reverse) Orientation.reverseComplement() else Orientation{}).compose(global_orientation),
             );
         },
     }

--- a/src/index_format.zig
+++ b/src/index_format.zig
@@ -10,7 +10,7 @@ const platform = @import("platform.zig");
 
 // --- Types shared by indexer, getter, and stats ---
 
-/// ZFI binary format magic + header (`ZFI\x01` since first release; no users on a prior on-disk layout).
+/// Four-byte magic and version for the supported `.zfi` wire format.
 pub const ZFI_MAGIC: [4]u8 = .{ 'Z', 'F', 'I', 0x01 };
 
 const NON_UNIFORM_WIDTH_FLAG: u8 = 1;
@@ -38,6 +38,7 @@ pub const ZFI_NAME_FOOTER_BYTES: usize = 12;
 pub const ZFI_SOURCE_ID_MAGIC: [4]u8 = .{ 'Z', 'F', 'I', 'D' };
 pub const ZFI_SOURCE_ID_BYTES: usize = 12;
 
+/// Encodes the trailing name-blob length in the frozen little-endian layout.
 pub fn encodeZfiNameFooter(name_blob_len: u64) [ZFI_NAME_FOOTER_BYTES]u8 {
     var out: [ZFI_NAME_FOOTER_BYTES]u8 = undefined;
     @memcpy(out[0..4], &ZFI_NAME_FOOTER_MAGIC);
@@ -45,6 +46,7 @@ pub fn encodeZfiNameFooter(name_blob_len: u64) [ZFI_NAME_FOOTER_BYTES]u8 {
     return out;
 }
 
+/// Encodes the source modification time in the frozen little-endian layout.
 pub fn encodeZfiSourceId(source_mtime_ns: u64) [ZFI_SOURCE_ID_BYTES]u8 {
     var out: [ZFI_SOURCE_ID_BYTES]u8 = undefined;
     @memcpy(out[0..4], &ZFI_SOURCE_ID_MAGIC);
@@ -67,16 +69,15 @@ fn decodeZfiSourceIdBytes(id_bytes: []const u8) ?u64 {
 // Legacy on-disk footer written before tight layout (16 bytes: magic + 4 pad + u64).
 const ZFI_NAME_FOOTER_LEGACY_BYTES: usize = 16;
 
-/// Nanoseconds since epoch as stored in `.zfi` source-identity trailers.
-pub fn timestampToNs(ts: std.Io.Timestamp) u64 {
-    return @intCast(ts.nanoseconds);
+/// Converts a non-negative timestamp to the unsigned `.zfi` representation.
+pub fn timestampToNs(ts: std.Io.Timestamp) error{TimestampOutOfRange}!u64 {
+    return std.math.cast(u64, ts.nanoseconds) orelse error.TimestampOutOfRange;
 }
 
 // Trailing layout after records/side tables:
 // `[name blob][optional ZFID][ZFNM footer]`.
 // `ZFID` sits before the footer so legacy loaders that seek `ZFNM` at EOF still work.
 const ZfiTrailingMeta = struct {
-    // End of name blob (and of the side-table region when the blob is empty).
     payload_end: usize,
     name_blob_len: u64,
     source_mtime_ns: ?u64,
@@ -124,6 +125,7 @@ fn parseZfiNameFooterAtEnd(zfi_data: []const u8) ?struct {
     return null;
 }
 
+/// Frozen 16-byte `.zfi` header.
 pub const ZfiHeader = extern struct {
     magic: [4]u8,
     record_count: u32,
@@ -141,17 +143,15 @@ pub const SideTableLine = extern struct {
     line_bases: u64,
 };
 
-/// Index record for ZFI output (40 bytes padded).
+/// Frozen 40-byte record shared by `.zfi` and normalized in-memory `.fai` loads.
 ///
 /// For `.zfi` indexes, `name_offset` / `name_len` point into the embedded name blob.
 /// For full-map `.fai` loads, they point into the mapped `.fai` line. Streamed
 /// `.fai` loads keep copied names separately. Use `LoadedIndex.recordName` when
 /// the index source is not already known.
 ///
-/// v0.3 stores non-uniform-width metadata in `_pad` so uniform records remain
-/// byte-identical to v0.2 records. `_pad[0] & 1 == 0` means the classic O(1)
-/// line formula applies. Non-uniform records store a 40-bit little-endian
-/// absolute `.zfi` side-table offset in `_pad[1..6]`.
+/// `_pad[0] & 1 == 0` selects the uniform O(1) line formula. Non-uniform records
+/// store a 40-bit little-endian absolute side-table offset in `_pad[1..6]`.
 pub const IndexRecord = extern struct {
     name_offset: u64,
     name_len: u16,
@@ -161,7 +161,8 @@ pub const IndexRecord = extern struct {
     line_bases: u32,
     line_bytes: u32,
 
-    /// Caller assumes the record name range was validated against `data`.
+    /// Caller assumes the record name range was validated against `data`; violating
+    /// this is undefined behavior.
     pub fn getName(self: IndexRecord, data: []const u8) []const u8 {
         return data[self.name_offset..][0..self.name_len];
     }
@@ -182,6 +183,7 @@ pub const IndexRecord = extern struct {
         return offset;
     }
 
+    /// Marks the record non-uniform or returns `SideTableOffsetTooLarge`.
     pub fn markNonUniform(self: *IndexRecord, offset: u64) !void {
         if (offset > MAX_SIDE_TABLE_OFFSET) return error.SideTableOffsetTooLarge;
         const preserve = self._pad[0] & NAME_IN_ZFI_FLAG;
@@ -250,7 +252,7 @@ pub fn encodeSideTableLine(line: SideTableLine) [ZFI_SIDE_TABLE_LINE_BYTES]u8 {
     return out;
 }
 
-/// Result of loading an index (from .zfi or .fai)
+/// Selects the records, names, and lookup state retained by a loader.
 pub const LoadMode = union(enum) {
     lookup_full_map,
     /// Stats composition: retain every record and only the two report names for streamed FAI.
@@ -319,6 +321,7 @@ pub const LoadedIndex = struct {
         return null;
     }
 
+    /// Releases all mappings, arena allocations, and the FASTA descriptor.
     pub fn deinit(self: *LoadedIndex) void {
         if (self.zfi_map) |*m| m.destroy(self.io);
         if (self.fai_map) |*m| m.destroy(self.io);
@@ -328,6 +331,7 @@ pub const LoadedIndex = struct {
         self.fasta_file.close(self.io);
     }
 
+    /// Returns the first retained record whose name exactly matches `name`.
     pub fn lookupName(self: *const LoadedIndex, name: []const u8) ?usize {
         if (self.name_map) |name_map| {
             const rec_idx = name_map.get(name) orelse return null;
@@ -358,6 +362,7 @@ pub const LoadedIndex = struct {
         return null;
     }
 
+    /// Returns borrowed lines for a loaded non-uniform record, or empty if unavailable.
     pub fn sideTableLines(self: *const LoadedIndex, rec: IndexRecord) []const SideTableLine {
         if (rec.isUniformWidth()) return &.{};
         const zfi = self.zfi_data orelse return &.{};
@@ -586,7 +591,8 @@ fn tryLoadZfi(
     // mtime was touched forward. Legacy files without a trailer keep the weaker
     // index-mtime check above only.
     if (name_layout.source_mtime_ns) |stored_mtime| {
-        if (stored_mtime != timestampToNs(fasta_stat.mtime)) {
+        const source_mtime = timestampToNs(fasta_stat.mtime) catch return error.StaleIndex;
+        if (stored_mtime != source_mtime) {
             return error.StaleIndex;
         }
     }
@@ -711,7 +717,7 @@ fn tryLoadFai(
             .line_bases = fields.line_bases,
             .line_bytes = fields.line_bytes,
         };
-        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
+        if (!isValidUniformSequenceGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
 
         if (record_count >= records.len) return error.CorruptIndex;
         records[record_count] = rec;
@@ -762,8 +768,8 @@ fn loadFaiStreamed(
     errdefer arena.deinit();
     const allocator = arena.allocator();
 
-    var records_list: std.ArrayListUnmanaged(IndexRecord) = .empty;
-    var slices_list: std.ArrayListUnmanaged([]const u8) = .empty;
+    var records_list: std.ArrayList(IndexRecord) = .empty;
+    var slices_list: std.ArrayList([]const u8) = .empty;
     var requested: std.StringHashMapUnmanaged(bool) = .empty;
     defer requested.deinit(backing_allocator);
     switch (mode) {
@@ -789,7 +795,10 @@ fn loadFaiStreamed(
     var longest_len: u64 = 0;
 
     while (true) {
-        const maybe_line = file_reader.interface.takeDelimiter('\n') catch return error.Io;
+        const maybe_line = file_reader.interface.takeDelimiter('\n') catch |err| switch (err) {
+            error.ReadFailed => return error.Io,
+            error.StreamTooLong => return error.CorruptIndex,
+        };
         const line = maybe_line orelse break;
         const current_offset = line_offset;
         line_offset = std.math.add(u64, line_offset, line.len + 1) catch return error.CorruptIndex;
@@ -805,7 +814,7 @@ fn loadFaiStreamed(
             .line_bases = fields.line_bases,
             .line_bytes = fields.line_bytes,
         };
-        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
+        if (!isValidUniformSequenceGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
 
         saw_record = true;
         const retain = switch (mode) {
@@ -981,11 +990,6 @@ fn parseFaiAsciiU32(text: []const u8) ?u32 {
     return std.math.cast(u32, wide);
 }
 
-// Samtools `.fai` is always uniform-width; dense `.zfi` records use the same layout.
-fn isValidFaiRecordGeometry(rec: IndexRecord, fasta_len: u64) bool {
-    return isValidUniformSequenceGeometry(rec, fasta_len);
-}
-
 // Shared by `.fai` loaders and uniform `.zfi` metadata checks.
 //
 // Reject zero or impossible `line_bases` / `line_bytes`, `seq_offset` past EOF, and
@@ -1064,8 +1068,8 @@ const ParsedSideTable = struct {
 // Validate one non-uniform record's side table before creating typed line pointers.
 //
 // The table must sit in `[side_region_start, side_region_end)`, be 8-byte aligned,
-// and describe `rec.seq_len` bases starting at `rec.seq_offset`. Line byte offsets
-// must strictly increase; checked arithmetic rejects wraps before any slice.
+// and describe `rec.seq_len` bases starting at `rec.seq_offset`. Line byte ranges
+// must be ordered and non-overlapping; checked arithmetic rejects wraps before any slice.
 fn parseSideTable(
     zfi_data: platform.MappedBytes,
     rec: IndexRecord,
@@ -1097,21 +1101,22 @@ fn parseSideTable(
     )[0..@intCast(line_count)];
 
     var expected_base_start: u64 = 0;
-    var previous_byte_offset: u64 = 0;
+    var previous_byte_end: u64 = 0;
     for (lines, 0..) |line, i| {
         if (line.base_start != expected_base_start) return null;
         if (line.line_bases == 0 or line.line_bytes == 0) return null;
         if (line.line_bytes < line.line_bases) return null;
-        if (line.byte_offset > fasta_len or line.line_bytes > fasta_len - line.byte_offset) return null;
+        const byte_end = std.math.add(u64, line.byte_offset, line.line_bytes) catch return null;
+        if (byte_end > fasta_len) return null;
         if (i == 0) {
             // Writer invariant: first base-bearing line begins at seq_offset.
             if (line.byte_offset != rec.seq_offset) return null;
-        } else if (line.byte_offset <= previous_byte_offset) {
+        } else if (line.byte_offset < previous_byte_end) {
             return null;
         }
 
         expected_base_start = std.math.add(u64, expected_base_start, line.line_bases) catch return null;
-        previous_byte_offset = line.byte_offset;
+        previous_byte_end = byte_end;
     }
 
     if (expected_base_start != rec.seq_len) return null;

--- a/src/index_format.zig
+++ b/src/index_format.zig
@@ -8,68 +8,63 @@ const std = @import("std");
 const builtin = @import("builtin");
 const platform = @import("platform.zig");
 
-// ============================================================================
-// Types - shared by indexer, getter, stats
-// ============================================================================
+// --- Types shared by indexer, getter, and stats ---
 
 /// ZFI binary format magic + header (`ZFI\x01` since first release; no users on a prior on-disk layout).
 pub const ZFI_MAGIC: [4]u8 = .{ 'Z', 'F', 'I', 0x01 };
 
 const NON_UNIFORM_WIDTH_FLAG: u8 = 1;
-const NAME_IN_ZFI_FLAG: u8 = 2;
-pub const name_in_zfi_flag = NAME_IN_ZFI_FLAG;
+/// Record flag indicating that its name is embedded in the `.zfi` name blob.
+pub const NAME_IN_ZFI_FLAG: u8 = 2;
 const SIDE_TABLE_OFFSET_BYTES = 5;
 const MAX_SIDE_TABLE_OFFSET = (1 << (SIDE_TABLE_OFFSET_BYTES * 8)) - 1;
 // Holds the maximum u16 name, four tabs, four maximum-width numeric fields,
 // and the line delimiter.
 const FAI_READER_BUFFER_BYTES: usize = 65_600;
 
-/// Maximum absolute side-table byte offset (`plan/docs/zfi-format.md`).
-pub const max_side_table_offset: u64 = MAX_SIDE_TABLE_OFFSET;
-
 pub const ZFI_NAME_FOOTER_MAGIC: [4]u8 = .{ 'Z', 'F', 'N', 'M' };
 
 /// On-disk sizes from the wire contract (must match `@sizeOf` under the frozen layout).
-pub const zfi_header_bytes: usize = 16;
-pub const zfi_index_record_bytes: usize = 40;
-pub const zfi_side_table_line_bytes: usize = 32;
+pub const ZFI_HEADER_BYTES: usize = 16;
+pub const ZFI_INDEX_RECORD_BYTES: usize = 40;
+pub const ZFI_SIDE_TABLE_LINE_BYTES: usize = 32;
 
 /// On-disk name-table footer size (4-byte magic + little-endian u64 length).
-pub const zfi_name_footer_bytes: usize = 12;
+pub const ZFI_NAME_FOOTER_BYTES: usize = 12;
 
 /// Trailing source-identity block (`ZFID` + FASTA mtime ns) written immediately
 /// before the name footer. Production writers always include it. Legacy files
 /// without it use the weaker mtime policy.
 pub const ZFI_SOURCE_ID_MAGIC: [4]u8 = .{ 'Z', 'F', 'I', 'D' };
-pub const zfi_source_id_bytes: usize = 12;
+pub const ZFI_SOURCE_ID_BYTES: usize = 12;
 
-pub fn encodeZfiNameFooter(name_blob_len: u64) [zfi_name_footer_bytes]u8 {
-    var out: [zfi_name_footer_bytes]u8 = undefined;
+pub fn encodeZfiNameFooter(name_blob_len: u64) [ZFI_NAME_FOOTER_BYTES]u8 {
+    var out: [ZFI_NAME_FOOTER_BYTES]u8 = undefined;
     @memcpy(out[0..4], &ZFI_NAME_FOOTER_MAGIC);
     std.mem.writeInt(u64, out[4..12], name_blob_len, .little);
     return out;
 }
 
-pub fn encodeZfiSourceId(source_mtime_ns: u64) [zfi_source_id_bytes]u8 {
-    var out: [zfi_source_id_bytes]u8 = undefined;
+pub fn encodeZfiSourceId(source_mtime_ns: u64) [ZFI_SOURCE_ID_BYTES]u8 {
+    var out: [ZFI_SOURCE_ID_BYTES]u8 = undefined;
     @memcpy(out[0..4], &ZFI_SOURCE_ID_MAGIC);
     std.mem.writeInt(u64, out[4..12], source_mtime_ns, .little);
     return out;
 }
 
 fn decodeZfiNameFooterBytes(footer_bytes: []const u8) ?u64 {
-    if (footer_bytes.len < zfi_name_footer_bytes) return null;
+    if (footer_bytes.len < ZFI_NAME_FOOTER_BYTES) return null;
     if (!std.mem.eql(u8, footer_bytes[0..4], &ZFI_NAME_FOOTER_MAGIC)) return null;
     return std.mem.readInt(u64, footer_bytes[4..12], .little);
 }
 
 fn decodeZfiSourceIdBytes(id_bytes: []const u8) ?u64 {
-    if (id_bytes.len < zfi_source_id_bytes) return null;
+    if (id_bytes.len < ZFI_SOURCE_ID_BYTES) return null;
     if (!std.mem.eql(u8, id_bytes[0..4], &ZFI_SOURCE_ID_MAGIC)) return null;
     return std.mem.readInt(u64, id_bytes[4..12], .little);
 }
 
-/// Legacy on-disk footer written before tight layout (16 bytes: magic + 4 pad + u64).
+// Legacy on-disk footer written before tight layout (16 bytes: magic + 4 pad + u64).
 const zfi_name_footer_legacy_bytes: usize = 16;
 
 /// Nanoseconds since epoch as stored in `.zfi` source-identity trailers.
@@ -77,35 +72,32 @@ pub fn timestampToNs(ts: std.Io.Timestamp) u64 {
     return @intCast(ts.nanoseconds);
 }
 
-/// Trailing layout after records/side tables:
-/// `[name blob][optional ZFID][ZFNM footer]`.
-/// `ZFID` sits *before* the footer so legacy loaders that seek `ZFNM` at EOF still work.
-pub const ZfiTrailingMeta = struct {
-    /// End of name blob (and of the side-table region when the blob is empty).
+// Trailing layout after records/side tables:
+// `[name blob][optional ZFID][ZFNM footer]`.
+// `ZFID` sits before the footer so legacy loaders that seek `ZFNM` at EOF still work.
+const ZfiTrailingMeta = struct {
+    // End of name blob (and of the side-table region when the blob is empty).
     payload_end: usize,
     name_blob_len: u64,
-    footer_bytes: usize,
     source_mtime_ns: ?u64,
 };
 
-pub fn parseZfiTrailingMeta(zfi_data: []const u8) ?ZfiTrailingMeta {
+fn parseZfiTrailingMeta(zfi_data: []const u8) ?ZfiTrailingMeta {
     const footer = parseZfiNameFooterAtEnd(zfi_data) orelse return null;
-    if (zfi_data.len < footer.footer_bytes) return null;
     const footer_start = zfi_data.len - footer.footer_bytes;
 
     var source_mtime_ns: ?u64 = null;
     var payload_end = footer_start;
-    if (footer_start >= zfi_source_id_bytes) {
-        if (decodeZfiSourceIdBytes(zfi_data[footer_start - zfi_source_id_bytes .. footer_start])) |mtime_ns| {
+    if (footer_start >= ZFI_SOURCE_ID_BYTES) {
+        if (decodeZfiSourceIdBytes(zfi_data[footer_start - ZFI_SOURCE_ID_BYTES .. footer_start])) |mtime_ns| {
             source_mtime_ns = mtime_ns;
-            payload_end = footer_start - zfi_source_id_bytes;
+            payload_end = footer_start - ZFI_SOURCE_ID_BYTES;
         }
     }
 
     return .{
         .payload_end = payload_end,
         .name_blob_len = footer.name_blob_len,
-        .footer_bytes = footer.footer_bytes,
         .source_mtime_ns = source_mtime_ns,
     };
 }
@@ -114,9 +106,9 @@ fn parseZfiNameFooterAtEnd(zfi_data: []const u8) ?struct {
     name_blob_len: u64,
     footer_bytes: usize,
 } {
-    if (zfi_data.len >= zfi_name_footer_bytes) {
-        if (decodeZfiNameFooterBytes(zfi_data[zfi_data.len - zfi_name_footer_bytes ..])) |name_blob_len| {
-            return .{ .name_blob_len = name_blob_len, .footer_bytes = zfi_name_footer_bytes };
+    if (zfi_data.len >= ZFI_NAME_FOOTER_BYTES) {
+        if (decodeZfiNameFooterBytes(zfi_data[zfi_data.len - ZFI_NAME_FOOTER_BYTES ..])) |name_blob_len| {
+            return .{ .name_blob_len = name_blob_len, .footer_bytes = ZFI_NAME_FOOTER_BYTES };
         }
     }
 
@@ -153,7 +145,7 @@ pub const SideTableLine = extern struct {
 ///
 /// For `.zfi` indexes, `name_offset` / `name_len` point into the embedded name blob.
 /// For full-map `.fai` loads, they point into the mapped `.fai` line. Streamed
-/// `.fai` loads keep copied names separately. Use `LoadedIndex.getRecordName` when
+/// `.fai` loads keep copied names separately. Use `LoadedIndex.recordName` when
 /// the index source is not already known.
 ///
 /// v0.3 stores non-uniform-width metadata in `_pad` so uniform records remain
@@ -169,6 +161,7 @@ pub const IndexRecord = extern struct {
     line_bases: u32,
     line_bytes: u32,
 
+    /// Caller assumes the record name range was validated against `data`.
     pub fn getName(self: IndexRecord, data: []const u8) []const u8 {
         return data[self.name_offset..][0..self.name_len];
     }
@@ -206,9 +199,9 @@ comptime {
     if (builtin.cpu.arch.endian() != .little) {
         @compileError(".zfi wire format requires little-endian (see plan/docs/zfi-format.md); big-endian codec not implemented");
     }
-    if (@sizeOf(ZfiHeader) != zfi_header_bytes) @compileError("ZfiHeader size drifted from wire contract");
-    if (@sizeOf(IndexRecord) != zfi_index_record_bytes) @compileError("IndexRecord size drifted from wire contract");
-    if (@sizeOf(SideTableLine) != zfi_side_table_line_bytes) @compileError("SideTableLine size drifted from wire contract");
+    if (@sizeOf(ZfiHeader) != ZFI_HEADER_BYTES) @compileError("ZfiHeader size drifted from wire contract");
+    if (@sizeOf(IndexRecord) != ZFI_INDEX_RECORD_BYTES) @compileError("IndexRecord size drifted from wire contract");
+    if (@sizeOf(SideTableLine) != ZFI_SIDE_TABLE_LINE_BYTES) @compileError("SideTableLine size drifted from wire contract");
     if (@offsetOf(ZfiHeader, "magic") != 0) @compileError("ZfiHeader.magic offset");
     if (@offsetOf(ZfiHeader, "record_count") != 4) @compileError("ZfiHeader.record_count offset");
     if (@offsetOf(ZfiHeader, "source_size") != 8) @compileError("ZfiHeader.source_size offset");
@@ -226,8 +219,8 @@ comptime {
 }
 
 /// Explicit little-endian header bytes (must match `asBytes` on little-endian hosts).
-pub fn encodeZfiHeader(header: ZfiHeader) [zfi_header_bytes]u8 {
-    var out: [zfi_header_bytes]u8 = undefined;
+pub fn encodeZfiHeader(header: ZfiHeader) [ZFI_HEADER_BYTES]u8 {
+    var out: [ZFI_HEADER_BYTES]u8 = undefined;
     @memcpy(out[0..4], &header.magic);
     std.mem.writeInt(u32, out[4..8], header.record_count, .little);
     std.mem.writeInt(u64, out[8..16], header.source_size, .little);
@@ -235,8 +228,8 @@ pub fn encodeZfiHeader(header: ZfiHeader) [zfi_header_bytes]u8 {
 }
 
 /// Explicit little-endian record bytes (must match `asBytes` on little-endian hosts).
-pub fn encodeIndexRecord(rec: IndexRecord) [zfi_index_record_bytes]u8 {
-    var out: [zfi_index_record_bytes]u8 = undefined;
+pub fn encodeIndexRecord(rec: IndexRecord) [ZFI_INDEX_RECORD_BYTES]u8 {
+    var out: [ZFI_INDEX_RECORD_BYTES]u8 = undefined;
     std.mem.writeInt(u64, out[0..8], rec.name_offset, .little);
     std.mem.writeInt(u16, out[8..10], rec.name_len, .little);
     @memcpy(out[10..16], &rec._pad);
@@ -248,8 +241,8 @@ pub fn encodeIndexRecord(rec: IndexRecord) [zfi_index_record_bytes]u8 {
 }
 
 /// Explicit little-endian side-table line bytes (must match `asBytes` on little-endian hosts).
-pub fn encodeSideTableLine(line: SideTableLine) [zfi_side_table_line_bytes]u8 {
-    var out: [zfi_side_table_line_bytes]u8 = undefined;
+pub fn encodeSideTableLine(line: SideTableLine) [ZFI_SIDE_TABLE_LINE_BYTES]u8 {
+    var out: [ZFI_SIDE_TABLE_LINE_BYTES]u8 = undefined;
     std.mem.writeInt(u64, out[0..8], line.base_start, .little);
     std.mem.writeInt(u64, out[8..16], line.byte_offset, .little);
     std.mem.writeInt(u64, out[16..24], line.line_bytes, .little);
@@ -268,28 +261,26 @@ pub const LoadMode = union(enum) {
 
 /// Loaded FASTA + index state (from `.zfi` or samtools-compatible `.fai`).
 ///
-/// Ownership (one owner each; `deinit(io)` is the only cleanup entry point):
-/// - **FASTA file and maps**: `fasta_file` remains open until `deinit`.
-///   `deinit` destroys the optional FASTA map and optional sidecar maps, then closes
-///   the FASTA file. Byte slices and typed views borrow from those maps.
+/// Ownership (one owner each; `deinit()` is the only cleanup entry point):
+/// - **FASTA file**: `fasta_file` remains open until `deinit`.
+/// - **Sidecar maps**: `deinit` destroys the optional `.zfi` / `.fai` maps. Byte
+///   slices and typed views borrow from those maps.
 /// - **Arena**: owns heap for streamed `.fai` record arrays and retained names,
 ///   plus `name_map` table storage. Reclaimed
 ///   only via `arena.deinit()` (do not `name_map.deinit()` on an arena-backed map).
 /// - **`name_map` keys**: borrowed from a sidecar map for full loads, or from
 ///   arena-owned `name_slices` for positional streamed `.fai` loads.
-/// - **`io`**: borrowed for destroy only; caller must keep it alive until `deinit`.
+/// - **`io`**: borrowed for reads and cleanup; caller must keep it alive until `deinit`.
 ///
-/// GET and stats load through this type and only call `deinit(io)`. Validator maps
-/// the FASTA independently, but uses this ownership model when it loads an index.
+/// GET and stats load through this type and only call `deinit()`. Validator maps
+/// the FASTA independently.
 pub const LoadedIndex = struct {
     io: std.Io,
     fasta_file: std.Io.File,
-    fasta_map: ?std.Io.File.MemoryMap,
     zfi_map: ?std.Io.File.MemoryMap = null,
     fai_map: ?std.Io.File.MemoryMap = null,
     records: []const IndexRecord,
-    name_map: std.StringHashMap(u32),
-    has_name_map: bool,
+    name_map: ?std.StringHashMapUnmanaged(u32) = null,
     /// Arena-owned names: one per retained positional record, or stats extrema only.
     name_slices: []const []const u8 = &.{},
     /// Record indices for the two extrema names retained by streamed FAI stats loads.
@@ -297,7 +288,6 @@ pub const LoadedIndex = struct {
     /// Borrow into `zfi_map` when `.zfi` embeds a name blob.
     name_blob: ?[]const u8 = null,
     fai_data: ?platform.MappedBytes = null,
-    fasta_data: []const u8,
     fasta_size: u64,
     zfi_data: ?platform.MappedBytes,
     zfi_side_start: usize = 0,
@@ -311,11 +301,14 @@ pub const LoadedIndex = struct {
         return if (self.source == .zfi) self.name_blob.? else self.fai_data.?;
     }
 
-    pub fn getRecordName(self: *const LoadedIndex, rec_idx: usize) []const u8 {
+    /// Returns a retained record name, or `null` when the selected load mode did
+    /// not retain that record's name.
+    pub fn recordName(self: *const LoadedIndex, rec_idx: usize) ?[]const u8 {
+        if (rec_idx >= self.records.len) return null;
         if (self.stats_name_indices) |indices| {
             if (rec_idx == indices[0]) return self.name_slices[0];
             if (rec_idx == indices[1]) return self.name_slices[1];
-            return "?";
+            return null;
         }
         if (self.name_slices.len > 0) {
             return self.name_slices[rec_idx];
@@ -323,30 +316,21 @@ pub const LoadedIndex = struct {
         const rec = self.records[rec_idx];
         if (self.source == .zfi) return rec.getName(self.name_blob.?);
         if (self.fai_data) |data| return rec.getName(data);
-        var it = self.name_map.iterator();
-        while (it.next()) |entry| {
-            if (@as(usize, entry.value_ptr.*) == rec_idx) {
-                return entry.key_ptr.*;
-            }
-        }
-        return "?";
+        return null;
     }
 
-    pub fn deinit(self: *LoadedIndex, io: std.Io) void {
-        if (self.fasta_map) |*m| m.destroy(io);
-        if (self.zfi_map) |*m| m.destroy(io);
-        if (self.fai_map) |*m| m.destroy(io);
-        // `name_map` table bytes are arena-owned. Keys borrow a sidecar map or
-        // arena-owned copied names. Do not call
-        // `name_map.deinit()`: Zig 0.16 ArenaAllocator.free is not safe for the
-        // HashMap's non-LIFO buffer free (crashes). `arena.deinit()` reclaims all.
+    pub fn deinit(self: *LoadedIndex) void {
+        if (self.zfi_map) |*m| m.destroy(self.io);
+        if (self.fai_map) |*m| m.destroy(self.io);
+        // `name_map` table bytes and copied names are arena-owned. The arena
+        // reclaims them together; individual container deinit calls are redundant.
         self.arena.deinit();
-        self.fasta_file.close(io);
+        self.fasta_file.close(self.io);
     }
 
     pub fn lookupName(self: *const LoadedIndex, name: []const u8) ?usize {
-        if (self.has_name_map) {
-            const rec_idx = self.name_map.get(name) orelse return null;
+        if (self.name_map) |name_map| {
+            const rec_idx = name_map.get(name) orelse return null;
             return rec_idx;
         }
 
@@ -408,60 +392,34 @@ pub const LoadIndexError = error{
     OutOfMemory,
 };
 
-// Internal result of tryLoadZfi / tryLoadFai before mapping onto LoadIndexError.
-//
-// `.not_found`, `.stale`, and `.corrupt` are success-typed tags, not Zig errors.
-// Returning them after mmap or arena allocation does not run errdefer. Loaders
-// therefore keep a `transferred` flag and free resources in a plain defer until
-// ownership moves into the returned LoadedIndex.
-const LoadAttempt = union(enum) {
-    loaded: LoadedIndex,
-    not_found,
-    stale,
-    corrupt,
-};
-
-// ============================================================================
-// Error helper (shared by main, getter, indexer)
-// ============================================================================
+// --- Shared error helper ---
 
 pub fn printErrorAndExit(comptime fmt: []const u8, args: anytype) noreturn {
     std.debug.print(fmt, args);
     std.process.exit(1);
 }
 
-// ============================================================================
-// Shared index loader
-// ============================================================================
+// --- Shared index loader ---
 
 /// Load the index for a FASTA file. A present `.zfi` is authoritative;
 /// `.fai` is considered only when `.zfi` is absent.
-/// The caller must call `deinit(io)` on the returned LoadedIndex.
-pub fn loadIndex(io: std.Io, fasta_path: []const u8) LoadedIndex {
-    return loadIndexWithMode(io, fasta_path, .lookup_full_map);
-}
-
-pub fn loadIndexWithMode(io: std.Io, fasta_path: []const u8, mode: LoadMode) LoadedIndex {
-    return switch (mode) {
-        .stats_scan => loadIndexWithAccess(io, fasta_path, mode, .file_backed),
-        else => loadIndexWithAccess(io, fasta_path, mode, .mapped),
-    };
+/// The caller must call `deinit()` on the returned LoadedIndex.
+pub fn loadIndex(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) LoadedIndex {
+    return loadIndexOrExit(allocator, io, fasta_path, .lookup_full_map);
 }
 
 /// Load all stats metadata while keeping the FASTA descriptor-backed.
-pub fn loadIndexForStats(io: std.Io, fasta_path: []const u8) LoadedIndex {
-    return loadIndexWithAccess(io, fasta_path, .stats_scan, .file_backed);
+pub fn loadIndexForStats(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) LoadedIndex {
+    return loadIndexOrExit(allocator, io, fasta_path, .stats_scan);
 }
 
 /// Keeps the FASTA open without retaining its contents in memory.
-pub fn loadIndexForGet(io: std.Io, fasta_path: []const u8, mode: LoadMode) LoadedIndex {
-    return loadIndexWithAccess(io, fasta_path, mode, .file_backed);
+pub fn loadIndexForGet(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8, mode: LoadMode) LoadedIndex {
+    return loadIndexOrExit(allocator, io, fasta_path, mode);
 }
 
-const FastaAccess = enum { mapped, file_backed };
-
-fn loadIndexWithAccess(io: std.Io, fasta_path: []const u8, mode: LoadMode, access: FastaAccess) LoadedIndex {
-    return loadIndexCheckedWithAccess(io, fasta_path, mode, access) catch |err| switch (err) {
+fn loadIndexOrExit(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8, mode: LoadMode) LoadedIndex {
+    return loadIndexCheckedWithMode(allocator, io, fasta_path, mode) catch |err| switch (err) {
         error.FileNotFound => printErrorAndExit("error: file not found: {s}\n", .{fasta_path}),
         error.AccessDenied => printErrorAndExit("error: access denied: {s}\n", .{fasta_path}),
         error.EmptyFile => printErrorAndExit("error: file is empty: {s}\n", .{fasta_path}),
@@ -479,31 +437,23 @@ fn loadIndexWithAccess(io: std.Io, fasta_path: []const u8, mode: LoadMode, acces
 }
 
 /// Load the index for a FASTA file with typed errors for testing.
-pub fn loadIndexChecked(io: std.Io, fasta_path: []const u8) LoadIndexError!LoadedIndex {
-    return loadIndexCheckedWithMode(io, fasta_path, .lookup_full_map);
+pub fn loadIndexChecked(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) LoadIndexError!LoadedIndex {
+    return loadIndexCheckedWithMode(allocator, io, fasta_path, .lookup_full_map);
 }
 
-pub fn loadIndexCheckedWithMode(io: std.Io, fasta_path: []const u8, mode: LoadMode) LoadIndexError!LoadedIndex {
-    return switch (mode) {
-        .stats_scan => loadIndexCheckedWithAccess(io, fasta_path, mode, .file_backed),
-        else => loadIndexCheckedWithAccess(io, fasta_path, mode, .mapped),
-    };
-}
-
-fn loadIndexCheckedWithAccess(
+/// Loads one index mode while returning typed errors instead of exiting.
+pub fn loadIndexCheckedWithMode(
+    allocator: std.mem.Allocator,
     io: std.Io,
     fasta_path: []const u8,
     mode: LoadMode,
-    access: FastaAccess,
 ) LoadIndexError!LoadedIndex {
-    // Open FASTA file
     const fasta_file = std.Io.Dir.cwd().openFile(io, fasta_path, .{}) catch |err| switch (err) {
         error.FileNotFound => return error.FileNotFound,
         error.AccessDenied => return error.AccessDenied,
         else => return error.Io,
     };
-    var fasta_transferred = false;
-    defer if (!fasta_transferred) fasta_file.close(io);
+    errdefer fasta_file.close(io);
 
     const fasta_stat = fasta_file.stat(io) catch return error.Io;
 
@@ -511,41 +461,17 @@ fn loadIndexCheckedWithAccess(
         return error.EmptyFile;
     }
 
-    var fasta_view: ?platform.FileView = if (access == .mapped)
-        try platform.FileView.mapFile(io, fasta_file, @intCast(fasta_stat.size))
-    else
-        null;
-    defer if (!fasta_transferred) {
-        if (fasta_view) |*view| view.destroy(io);
-    };
-
     // A present `.zfi` is authoritative, including when it is invalid.
     var zfi_path_buf: [4096]u8 = undefined;
     const zfi_path = std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{fasta_path}) catch return error.PathTooLong;
 
-    switch (try tryLoadZfi(io, zfi_path, fasta_file, &fasta_view, fasta_stat, mode)) {
-        .loaded => |result| {
-            fasta_transferred = true;
-            return result;
-        },
-        .stale => return error.StaleIndex,
-        .corrupt => return error.CorruptIndex,
-        .not_found => {},
-    }
+    if (try tryLoadZfi(allocator, io, zfi_path, fasta_file, fasta_stat, mode)) |loaded| return loaded;
 
     // Try `.fai` only when `.zfi` is absent.
     var fai_path_buf: [4096]u8 = undefined;
     const fai_path = std.fmt.bufPrint(&fai_path_buf, "{s}.fai", .{fasta_path}) catch return error.PathTooLong;
 
-    switch (try tryLoadFai(io, fai_path, fasta_file, &fasta_view, fasta_stat, mode)) {
-        .loaded => |result| {
-            fasta_transferred = true;
-            return result;
-        },
-        .stale => return error.StaleIndex,
-        .corrupt => return error.CorruptIndex,
-        .not_found => return error.NoIndexFound,
-    }
+    return (try tryLoadFai(allocator, io, fai_path, fasta_file, fasta_stat, mode)) orelse error.NoIndexFound;
 }
 
 // Partition name-blob / footer relative to the records region.
@@ -583,9 +509,9 @@ fn buildNameMapFast(
     allocator: std.mem.Allocator,
     records: []const IndexRecord,
     name_data: []const u8,
-) LoadIndexError!std.StringHashMap(u32) {
-    var name_map = std.StringHashMap(u32).init(allocator);
-    name_map.ensureTotalCapacity(@intCast(records.len)) catch return error.OutOfMemory;
+) LoadIndexError!std.StringHashMapUnmanaged(u32) {
+    var name_map: std.StringHashMapUnmanaged(u32) = .empty;
+    name_map.ensureTotalCapacity(allocator, @intCast(records.len)) catch return error.OutOfMemory;
     for (records, 0..) |rec, i| {
         const name = rec.getName(name_data);
         const entry = name_map.getOrPutAssumeCapacity(name);
@@ -595,15 +521,15 @@ fn buildNameMapFast(
 }
 
 fn tryLoadZfi(
+    backing_allocator: std.mem.Allocator,
     io: std.Io,
     zfi_path: []const u8,
     fasta_file: std.Io.File,
-    fasta_view: *?platform.FileView,
     fasta_stat: std.Io.File.Stat,
     mode: LoadMode,
-) LoadIndexError!LoadAttempt {
+) LoadIndexError!?LoadedIndex {
     const zfi_file = std.Io.Dir.cwd().openFile(io, zfi_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return .not_found,
+        error.FileNotFound => return null,
         error.AccessDenied => return error.AccessDenied,
         else => return error.Io,
     };
@@ -613,45 +539,42 @@ fn tryLoadZfi(
 
     // Check for 0-byte file before mmap (POSIX returns EINVAL)
     if (zfi_stat.size == 0) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
     // Staleness: index file older than FASTA (both formats). `.fai` has no embedded
     // source size/mtime, so this plus "index not older" is its entire identity check.
     if (zfi_stat.mtime.nanoseconds < fasta_stat.mtime.nanoseconds) {
-        return .stale;
+        return error.StaleIndex;
     }
 
-    var zfi_view = platform.FileView.mapFile(io, zfi_file, @intCast(zfi_stat.size)) catch return error.MmapFailed;
-    // Free mmap on `.corrupt` / `.stale` / error until ownership moves into LoadedIndex.
-    var transferred = false;
-    defer if (!transferred) zfi_view.destroy(io);
+    var zfi_map = platform.mapFileReadOnly(io, zfi_file, @intCast(zfi_stat.size)) catch return error.MmapFailed;
+    errdefer zfi_map.destroy(io);
 
-    const fasta_data: []const u8 = if (fasta_view.*) |*view| view.bytes() else &.{};
-    const zfi_data = zfi_view.bytes();
+    const zfi_data: platform.MappedBytes = zfi_map.memory;
 
     // Validate minimum size for header
     if (zfi_data.len < @sizeOf(ZfiHeader)) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
     // Validate magic
     const header: *const ZfiHeader = @ptrCast(@alignCast(zfi_data.ptr));
     if (!std.mem.eql(u8, &header.magic, &ZFI_MAGIC)) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
     // Validate source file size (embedded identity).
     if (header.source_size != fasta_stat.size) {
-        return .stale;
+        return error.StaleIndex;
     }
 
     // Empty catalogs are not useful and match the `.fai` reject-empty policy.
-    if (header.record_count == 0) return .corrupt;
+    if (header.record_count == 0) return error.CorruptIndex;
 
     // Checked records extent before forming the typed record slice.
-    const records_end = zfiRecordsEnd(header.record_count) orelse return .corrupt;
-    if (zfi_data.len < records_end) return .corrupt;
+    const records_end = zfiRecordsEnd(header.record_count) orelse return error.CorruptIndex;
+    if (zfi_data.len < records_end) return error.CorruptIndex;
 
     const record_bytes = zfi_data[@sizeOf(ZfiHeader)..records_end];
     const records: []const IndexRecord = @as(
@@ -659,7 +582,7 @@ fn tryLoadZfi(
         @ptrCast(@alignCast(record_bytes.ptr)),
     )[0..header.record_count];
 
-    const name_layout = resolveZfiNameLayout(zfi_data, records_end, records) orelse return .corrupt;
+    const name_layout = resolveZfiNameLayout(zfi_data, records_end, records) orelse return error.CorruptIndex;
     const name_blob = name_layout.bytes;
 
     // Strong identity: production trailers store the FASTA mtime at index time.
@@ -668,7 +591,7 @@ fn tryLoadZfi(
     // index-mtime check above only.
     if (name_layout.source_mtime_ns) |stored_mtime| {
         if (stored_mtime != timestampToNs(fasta_stat.mtime)) {
-            return .stale;
+            return error.StaleIndex;
         }
     }
 
@@ -677,12 +600,11 @@ fn tryLoadZfi(
     const side_region_end = name_layout.start;
 
     if (!validateZfiRecords(records, fasta_stat.size, zfi_data, name_blob, side_region_start, side_region_end)) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    // Free arena on error until ownership moves into LoadedIndex.
-    defer if (!transferred) arena.deinit();
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
     const allocator = arena.allocator();
 
     const build_name_map = switch (mode) {
@@ -691,46 +613,38 @@ fn tryLoadZfi(
         .stats_scan => false,
     };
 
-    var name_map: std.StringHashMap(u32) = undefined;
-    var has_name_map = false;
-    if (build_name_map) {
-        name_map = buildNameMapFast(allocator, records, name_blob) catch return error.OutOfMemory;
-        has_name_map = true;
-    } else {
-        name_map = std.StringHashMap(u32).init(allocator);
-    }
+    const name_map = if (build_name_map)
+        buildNameMapFast(allocator, records, name_blob) catch return error.OutOfMemory
+    else
+        null;
 
-    transferred = true;
-    return .{ .loaded = LoadedIndex{
+    return LoadedIndex{
         .io = io,
         .fasta_file = fasta_file,
-        .fasta_map = if (fasta_view.*) |view| view.map else null,
-        .zfi_map = zfi_view.map,
+        .zfi_map = zfi_map,
         .records = records,
         .name_map = name_map,
-        .has_name_map = has_name_map,
         .name_slices = &.{},
         .name_blob = name_blob,
-        .fasta_data = fasta_data,
         .fasta_size = fasta_stat.size,
         .zfi_data = zfi_data,
         .zfi_side_start = side_region_start,
         .zfi_side_end = side_region_end,
         .source = .zfi,
         .arena = arena,
-    } };
+    };
 }
 
 fn tryLoadFai(
+    backing_allocator: std.mem.Allocator,
     io: std.Io,
     fai_path: []const u8,
     fasta_file: std.Io.File,
-    fasta_view: *?platform.FileView,
     fasta_stat: std.Io.File.Stat,
     mode: LoadMode,
-) LoadIndexError!LoadAttempt {
+) LoadIndexError!?LoadedIndex {
     const fai_file = std.Io.Dir.cwd().openFile(io, fai_path, .{}) catch |err| switch (err) {
-        error.FileNotFound => return .not_found,
+        error.FileNotFound => return null,
         error.AccessDenied => return error.AccessDenied,
         else => return error.Io,
     };
@@ -741,44 +655,37 @@ fn tryLoadFai(
     // `.fai` identity is mtime-only: the text format has no source size or mtime field.
     // Same-size FASTA replacement is detected only when the FASTA mtime moves forward.
     if (fai_stat.mtime.nanoseconds < fasta_stat.mtime.nanoseconds) {
-        return .stale;
+        return error.StaleIndex;
     }
 
     if (fai_stat.size == 0) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
-    const fasta_data: []const u8 = if (fasta_view.*) |*view| view.bytes() else &.{};
-
     switch (mode) {
-        .stats_scan => return loadFaiStreamed(io, fai_file, fasta_file, fasta_view, fasta_stat, .stats_scan),
-        .positional => |names| return loadFaiStreamed(io, fai_file, fasta_file, fasta_view, fasta_stat, .{ .matched = names }),
+        .stats_scan => return @as(?LoadedIndex, try loadFaiStreamed(backing_allocator, io, fai_file, fasta_file, fasta_stat, .stats_scan)),
+        .positional => |names| return @as(?LoadedIndex, try loadFaiStreamed(backing_allocator, io, fai_file, fasta_file, fasta_stat, .{ .matched = names })),
         .lookup_full_map => {},
     }
 
-    var fai_view = platform.FileView.mapFile(io, fai_file, @intCast(fai_stat.size)) catch return error.MmapFailed;
+    var fai_map = platform.mapFileReadOnly(io, fai_file, @intCast(fai_stat.size)) catch return error.MmapFailed;
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    // Free mmap + arena on `.corrupt` / error until ownership moves into LoadedIndex.
-    var transferred = false;
-    defer {
-        if (!transferred) {
-            fai_view.destroy(io);
-            arena.deinit();
-        }
-    }
+    errdefer fai_map.destroy(io);
+
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
     const allocator = arena.allocator();
 
-    const fai_data = fai_view.bytes();
+    const fai_data: platform.MappedBytes = fai_map.memory;
 
     // Newline count undercounts by one when the final `.fai` line has no trailing `\n`.
     var approx_records = std.mem.count(u8, fai_data, "\n");
     if (fai_data.len > 0 and fai_data[fai_data.len - 1] != '\n') {
-        approx_records = std.math.add(usize, approx_records, 1) catch return .corrupt;
+        approx_records = std.math.add(usize, approx_records, 1) catch return error.CorruptIndex;
     }
     // Reject sizes that would overflow the records allocation.
-    _ = std.math.mul(usize, approx_records, @sizeOf(IndexRecord)) catch return .corrupt;
-    if (approx_records == 0) return .corrupt;
+    _ = std.math.mul(usize, approx_records, @sizeOf(IndexRecord)) catch return error.CorruptIndex;
+    if (approx_records == 0) return error.CorruptIndex;
     const records = allocator.alloc(IndexRecord, approx_records) catch return error.OutOfMemory;
 
     var record_count: usize = 0;
@@ -787,17 +694,17 @@ fn tryLoadFai(
         const line_start = pos;
         const rel_eol = std.mem.indexOfScalar(u8, fai_data[pos..], '\n') orelse fai_data.len - pos;
         const line_len = rel_eol;
-        const line_end = std.math.add(usize, line_start, line_len) catch return .corrupt;
+        const line_end = std.math.add(usize, line_start, line_len) catch return error.CorruptIndex;
         // Advance past `\n` only when present; a final line may omit it.
         if (line_end < fai_data.len) {
-            pos = std.math.add(usize, line_end, 1) catch return .corrupt;
+            pos = std.math.add(usize, line_end, 1) catch return error.CorruptIndex;
         } else {
             pos = line_end;
         }
         if (line_len == 0) continue;
 
         const line = fai_data[line_start..][0..line_len];
-        const fields = parseFaiIndexLine(line) catch return .corrupt;
+        const fields = parseFaiIndexLine(line) catch return error.CorruptIndex;
 
         const rec = IndexRecord{
             .name_offset = line_start,
@@ -807,37 +714,33 @@ fn tryLoadFai(
             .line_bases = fields.line_bases,
             .line_bytes = fields.line_bytes,
         };
-        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return .corrupt;
+        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
 
-        if (record_count >= records.len) return .corrupt;
+        if (record_count >= records.len) return error.CorruptIndex;
         records[record_count] = rec;
         record_count += 1;
     }
 
     if (record_count == 0) {
-        return .corrupt;
+        return error.CorruptIndex;
     }
 
     const loaded_records = records[0..record_count];
     const name_map = buildNameMapFast(allocator, loaded_records, fai_data) catch return error.OutOfMemory;
 
-    transferred = true;
-    return .{ .loaded = LoadedIndex{
+    return LoadedIndex{
         .io = io,
         .fasta_file = fasta_file,
-        .fasta_map = if (fasta_view.*) |view| view.map else null,
-        .fai_map = fai_view.map,
+        .fai_map = fai_map,
         .records = loaded_records,
         .name_map = name_map,
-        .has_name_map = true,
         .name_slices = &.{},
         .fai_data = fai_data,
-        .fasta_data = fasta_data,
         .fasta_size = fasta_stat.size,
         .zfi_data = null,
         .source = .fai,
         .arena = arena,
-    } };
+    };
 }
 
 const FaiStreamMode = union(enum) {
@@ -851,29 +754,24 @@ const FaiNameRef = struct {
 };
 
 fn loadFaiStreamed(
+    backing_allocator: std.mem.Allocator,
     io: std.Io,
     fai_file: std.Io.File,
     fasta_file: std.Io.File,
-    fasta_view: *?platform.FileView,
     fasta_stat: std.Io.File.Stat,
     mode: FaiStreamMode,
-) LoadIndexError!LoadAttempt {
-    const fasta_data: []const u8 = if (fasta_view.*) |*view| view.bytes() else &.{};
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    // Free arena on `.corrupt` / error until ownership moves into LoadedIndex.
-    var transferred = false;
-    defer if (!transferred) arena.deinit();
+) LoadIndexError!LoadedIndex {
+    var arena = std.heap.ArenaAllocator.init(backing_allocator);
+    errdefer arena.deinit();
     const allocator = arena.allocator();
 
     var records_list: std.ArrayListUnmanaged(IndexRecord) = .empty;
-    errdefer records_list.deinit(allocator);
     var slices_list: std.ArrayListUnmanaged([]const u8) = .empty;
-    errdefer slices_list.deinit(allocator);
-    var requested = std.StringHashMap(bool).init(std.heap.page_allocator);
-    defer requested.deinit();
+    var requested: std.StringHashMapUnmanaged(bool) = .empty;
+    defer requested.deinit(backing_allocator);
     switch (mode) {
         .matched => |names| {
-            requested.ensureTotalCapacity(@intCast(names.len)) catch return error.OutOfMemory;
+            requested.ensureTotalCapacity(backing_allocator, @intCast(names.len)) catch return error.OutOfMemory;
             for (names) |name| {
                 const entry = requested.getOrPutAssumeCapacity(name);
                 if (!entry.found_existing) entry.value_ptr.* = false;
@@ -897,10 +795,10 @@ fn loadFaiStreamed(
         const maybe_line = file_reader.interface.takeDelimiter('\n') catch return error.Io;
         const line = maybe_line orelse break;
         const current_offset = line_offset;
-        line_offset = std.math.add(u64, line_offset, line.len + 1) catch return .corrupt;
+        line_offset = std.math.add(u64, line_offset, line.len + 1) catch return error.CorruptIndex;
         if (line.len == 0) continue;
 
-        const fields = parseFaiIndexLine(line) catch return .corrupt;
+        const fields = parseFaiIndexLine(line) catch return error.CorruptIndex;
 
         const rec = IndexRecord{
             .name_offset = 0,
@@ -910,7 +808,7 @@ fn loadFaiStreamed(
             .line_bases = fields.line_bases,
             .line_bytes = fields.line_bytes,
         };
-        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return .corrupt;
+        if (!isValidFaiRecordGeometry(rec, fasta_stat.size)) return error.CorruptIndex;
 
         saw_record = true;
         const retain = switch (mode) {
@@ -947,60 +845,56 @@ fn loadFaiStreamed(
         try records_list.append(allocator, rec);
     }
 
-    if (!saw_record) return .corrupt;
+    if (!saw_record) return error.CorruptIndex;
 
     const owned_records = records_list.toOwnedSlice(allocator) catch return error.OutOfMemory;
     const owned_slices = switch (mode) {
         .matched => slices_list.toOwnedSlice(allocator) catch return error.OutOfMemory,
         .stats_scan => blk: {
             const names = allocator.alloc([]const u8, 2) catch return error.OutOfMemory;
-            names[0] = try readFaiName(io, fai_file, allocator, shortest_ref);
+            names[0] = try readFaiName(allocator, io, fai_file, shortest_ref);
             names[1] = if (shortest_index == longest_index)
                 names[0]
             else
-                try readFaiName(io, fai_file, allocator, longest_ref);
+                try readFaiName(allocator, io, fai_file, longest_ref);
             break :blk names;
         },
     };
 
-    var name_map = std.StringHashMap(u32).init(allocator);
-    const has_name_map = switch (mode) {
-        .matched => true,
-        .stats_scan => false,
+    const name_map: ?std.StringHashMapUnmanaged(u32) = switch (mode) {
+        .matched => blk: {
+            var map: std.StringHashMapUnmanaged(u32) = .empty;
+            map.ensureTotalCapacity(allocator, @intCast(owned_slices.len)) catch return error.OutOfMemory;
+            for (owned_slices, 0..) |name, i| {
+                map.putAssumeCapacity(name, @intCast(i));
+            }
+            break :blk map;
+        },
+        .stats_scan => null,
     };
-    if (has_name_map) {
-        name_map.ensureTotalCapacity(@intCast(owned_slices.len)) catch return error.OutOfMemory;
-        for (owned_slices, 0..) |name, i| {
-            name_map.putAssumeCapacity(name, @intCast(i));
-        }
-    }
 
-    transferred = true;
-    return .{ .loaded = LoadedIndex{
+    return LoadedIndex{
         .io = io,
         .fasta_file = fasta_file,
-        .fasta_map = if (fasta_view.*) |view| view.map else null,
         .records = owned_records,
         .name_map = name_map,
-        .has_name_map = has_name_map,
         .name_slices = owned_slices,
         .stats_name_indices = switch (mode) {
             .matched => null,
             .stats_scan => .{ shortest_index, longest_index },
         },
         .fai_data = null,
-        .fasta_data = fasta_data,
         .fasta_size = fasta_stat.size,
         .zfi_data = null,
         .source = .fai,
         .arena = arena,
-    } };
+    };
 }
 
 fn readFaiName(
+    allocator: std.mem.Allocator,
     io: std.Io,
     fai_file: std.Io.File,
-    allocator: std.mem.Allocator,
     name_ref: FaiNameRef,
 ) LoadIndexError![]const u8 {
     const name = allocator.alloc(u8, name_ref.len) catch return error.OutOfMemory;
@@ -1034,9 +928,7 @@ fn parseFaiFieldU32(line: []const u8, field_start: *usize) LoadIndexError!u32 {
     return value;
 }
 
-// ============================================================================
-// FAI field parsing and uniform geometry checks
-// ============================================================================
+// --- FAI field parsing and uniform geometry checks ---
 
 // One parsed `.fai` text line. Shared by mmap and streaming loaders so a missing
 // terminal newline cannot make the two paths disagree on field values.

--- a/src/index_format.zig
+++ b/src/index_format.zig
@@ -65,7 +65,7 @@ fn decodeZfiSourceIdBytes(id_bytes: []const u8) ?u64 {
 }
 
 // Legacy on-disk footer written before tight layout (16 bytes: magic + 4 pad + u64).
-const zfi_name_footer_legacy_bytes: usize = 16;
+const ZFI_NAME_FOOTER_LEGACY_BYTES: usize = 16;
 
 /// Nanoseconds since epoch as stored in `.zfi` source-identity trailers.
 pub fn timestampToNs(ts: std.Io.Timestamp) u64 {
@@ -113,11 +113,11 @@ fn parseZfiNameFooterAtEnd(zfi_data: []const u8) ?struct {
     }
 
     // Legacy 16-byte footer: magic + 4 pad bytes + little-endian u64 length.
-    if (zfi_data.len >= zfi_name_footer_legacy_bytes) {
-        const tail = zfi_data[zfi_data.len - zfi_name_footer_legacy_bytes ..];
+    if (zfi_data.len >= ZFI_NAME_FOOTER_LEGACY_BYTES) {
+        const tail = zfi_data[zfi_data.len - ZFI_NAME_FOOTER_LEGACY_BYTES ..];
         if (std.mem.eql(u8, tail[0..4], &ZFI_NAME_FOOTER_MAGIC)) {
             const name_blob_len = std.mem.readInt(u64, tail[8..16], .little);
-            return .{ .name_blob_len = name_blob_len, .footer_bytes = zfi_name_footer_legacy_bytes };
+            return .{ .name_blob_len = name_blob_len, .footer_bytes = ZFI_NAME_FOOTER_LEGACY_BYTES };
         }
     }
 
@@ -474,8 +474,6 @@ pub fn loadIndexCheckedWithMode(
     return (try tryLoadFai(allocator, io, fai_path, fasta_file, fasta_stat, mode)) orelse error.NoIndexFound;
 }
 
-// Partition name-blob / footer relative to the records region.
-//
 // Current indexes embed every name and end with `[name blob][ZFID][ZFNM footer]`.
 // The source-identity block remains optional for supported early embedded-name files.
 const ZfiNameLayout = struct {
@@ -548,23 +546,21 @@ fn tryLoadZfi(
         return error.StaleIndex;
     }
 
-    var zfi_map = platform.mapFileReadOnly(io, zfi_file, @intCast(zfi_stat.size)) catch return error.MmapFailed;
+    const zfi_size = std.math.cast(usize, zfi_stat.size) orelse return error.MmapFailed;
+    var zfi_map = platform.mapFileReadOnly(io, zfi_file, zfi_size) catch return error.MmapFailed;
     errdefer zfi_map.destroy(io);
 
     const zfi_data: platform.MappedBytes = zfi_map.memory;
 
-    // Validate minimum size for header
     if (zfi_data.len < @sizeOf(ZfiHeader)) {
         return error.CorruptIndex;
     }
 
-    // Validate magic
     const header: *const ZfiHeader = @ptrCast(@alignCast(zfi_data.ptr));
     if (!std.mem.eql(u8, &header.magic, &ZFI_MAGIC)) {
         return error.CorruptIndex;
     }
 
-    // Validate source file size (embedded identity).
     if (header.source_size != fasta_stat.size) {
         return error.StaleIndex;
     }
@@ -668,7 +664,8 @@ fn tryLoadFai(
         .lookup_full_map => {},
     }
 
-    var fai_map = platform.mapFileReadOnly(io, fai_file, @intCast(fai_stat.size)) catch return error.MmapFailed;
+    const fai_size = std.math.cast(usize, fai_stat.size) orelse return error.MmapFailed;
+    var fai_map = platform.mapFileReadOnly(io, fai_file, fai_size) catch return error.MmapFailed;
 
     errdefer fai_map.destroy(io);
 
@@ -692,7 +689,7 @@ fn tryLoadFai(
     var pos: usize = 0;
     while (pos < fai_data.len) {
         const line_start = pos;
-        const rel_eol = std.mem.indexOfScalar(u8, fai_data[pos..], '\n') orelse fai_data.len - pos;
+        const rel_eol = std.mem.findScalar(u8, fai_data[pos..], '\n') orelse fai_data.len - pos;
         const line_len = rel_eol;
         const line_end = std.math.add(usize, line_start, line_len) catch return error.CorruptIndex;
         // Advance past `\n` only when present; a final line may omit it.
@@ -910,7 +907,7 @@ fn parseFaiFieldU64(line: []const u8, field_start: *usize) LoadIndexError!u64 {
     }
     if (field_start.* >= line.len) return error.CorruptIndex;
 
-    const field_end = std.mem.indexOfScalarPos(u8, line, field_start.*, '\t') orelse line.len;
+    const field_end = std.mem.findScalarPos(u8, line, field_start.*, '\t') orelse line.len;
     const value = parseFaiAsciiU64(line[field_start.*..field_end]) orelse return error.CorruptIndex;
     field_start.* = field_end;
     return value;
@@ -922,7 +919,7 @@ fn parseFaiFieldU32(line: []const u8, field_start: *usize) LoadIndexError!u32 {
     }
     if (field_start.* >= line.len) return error.CorruptIndex;
 
-    const field_end = std.mem.indexOfScalarPos(u8, line, field_start.*, '\t') orelse line.len;
+    const field_end = std.mem.findScalarPos(u8, line, field_start.*, '\t') orelse line.len;
     const value = parseFaiAsciiU32(line[field_start.*..field_end]) orelse return error.CorruptIndex;
     field_start.* = field_end;
     return value;
@@ -942,7 +939,7 @@ const FaiLineFields = struct {
 };
 
 fn parseFaiIndexLine(line: []const u8) LoadIndexError!FaiLineFields {
-    const name_end = std.mem.indexOfScalar(u8, line, '\t') orelse return error.CorruptIndex;
+    const name_end = std.mem.findScalar(u8, line, '\t') orelse return error.CorruptIndex;
     const name_len = faiNameLen(name_end) orelse return error.CorruptIndex;
     var field_start: usize = name_end + 1;
     const seq_len = try parseFaiFieldU64(line, &field_start);
@@ -1058,7 +1055,6 @@ fn validateZfiRecords(
     return true;
 }
 
-// Parsed side-table location inside the side-table region.
 const ParsedSideTable = struct {
     start: usize,
     end: usize,

--- a/src/indexer.zig
+++ b/src/indexer.zig
@@ -190,7 +190,7 @@ pub const FastaRecordEmit = struct {
     uses_uniform_formula: bool,
     /// Incremental side-table bytes for `.zfi` (line count plus `SideTableLine` rows).
     side_table: []const u8 = &.{},
-    /// When true, `record` already has blob-relative `name_offset`/`name_len` and `name_in_zfi_flag`
+    /// When true, `record` already has blob-relative `name_offset`/`name_len` and `NAME_IN_ZFI_FLAG`
     /// (`.zfi` blob-backed `NameDedup`); skip `embedZfiName`.
     name_embedded: bool = false,
 };
@@ -465,7 +465,7 @@ fn embedZfiName(
     rec.name_offset = name_blob.items.len;
     rec.name_len = @intCast(name.len);
     try name_blob.appendSlice(allocator, name);
-    rec._pad[0] |= index_format.name_in_zfi_flag;
+    rec._pad[0] |= index_format.NAME_IN_ZFI_FLAG;
 }
 
 pub fn scanZfiReader(
@@ -928,7 +928,7 @@ const ChunkParseState = struct {
             if (seen.bindsToBlob()) {
                 name_offset = seen.last_offset;
                 out_name_len = seen.last_len;
-                name_pad[0] = index_format.name_in_zfi_flag;
+                name_pad[0] = index_format.NAME_IN_ZFI_FLAG;
                 name_embedded = true;
             }
         }

--- a/src/indexer.zig
+++ b/src/indexer.zig
@@ -1708,19 +1708,15 @@ test "[integration] - [source identity]: detects path replacement" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const before = blk: {
-        const original = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
-        defer original.close(std.testing.io);
-        try std.Io.File.writeStreamingAll(original, std.testing.io, ">seq\nAAAA\n");
-        break :blk try original.stat(std.testing.io);
-    };
+    const original = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+    try std.Io.File.writeStreamingAll(original, std.testing.io, ">seq\nAAAA\n");
+    const before = try original.stat(std.testing.io);
+    original.close(std.testing.io);
 
     try tmp.dir.rename("source.fa", tmp.dir, "old.fa", std.testing.io);
-    {
-        const replacement = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
-        defer replacement.close(std.testing.io);
-        try std.Io.File.writeStreamingAll(replacement, std.testing.io, ">seq\nA\n");
-    }
+    const replacement = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+    try std.Io.File.writeStreamingAll(replacement, std.testing.io, ">seq\nA\n");
+    replacement.close(std.testing.io);
 
     try std.testing.expect(!try sourcePathUnchanged(std.testing.io, tmp.dir, "source.fa", before));
 }

--- a/src/indexer.zig
+++ b/src/indexer.zig
@@ -2,7 +2,7 @@
 //!
 //! The parser skips empty lines for geometry, sets `seq_offset` to the first base-bearing
 //! line, invents a separator when the final line has no newline, and rejects names longer
-//! than `max_index_name_len`. Proven dense blocks update the same `ChunkParseState`; the
+//! than `MAX_INDEX_NAME_LEN`. Proven dense blocks update the same `ChunkParseState`; the
 //! first anomaly resumes the general line machine at the exact unconsumed byte.
 //!
 //! Duplicate-name filtering is first-wins and collision-safe: lookup may use a hash, but
@@ -22,7 +22,7 @@ const STRIDE_VECTOR_LEN = std.simd.suggestVectorLength(u8) orelse 1;
 // Processes 256 lines per proof batch without additional storage.
 const STRIDE_VALIDATION_BLOCK_LINES = 256;
 // The input payload occupies this fixed stack buffer regardless of FASTA size.
-pub const index_read_buffer_size = 1 * 1024 * 1024;
+pub const INDEX_READ_BUFFER_SIZE = 1 * 1024 * 1024;
 const FILE_IO_BUF_SIZE = 8 * 1024;
 // Each output and replay stage uses one fixed stack buffer of this size.
 const INDEX_OUTPUT_BUFFER_SIZE = 64 * 1024;
@@ -36,7 +36,7 @@ const FAI_U64_DECIMAL_DIGITS = 20;
 const FAI_SUFFIX_BUFFER_SIZE = 4 * (1 + FAI_U64_DECIMAL_DIGITS) + 1;
 // Exclusive creation retries only random name collisions within one directory.
 const FAI_SPOOL_CREATE_ATTEMPTS = 16;
-pub const max_index_name_len = std.math.maxInt(u16);
+pub const MAX_INDEX_NAME_LEN = std.math.maxInt(u16);
 
 pub const ScanOptions = struct {
     enable_dedup: bool,
@@ -53,10 +53,8 @@ pub const IndexOptions = struct {
 // Offset into a name blob for `.zfi` catalog dedup (one store for map and output).
 const NameBlobRef = struct { off: u32, len: u32 };
 
-/// First-wins name set for indexing. A hash accelerates the map; discarding a record
-/// requires full-string equality (`Context.eql`), never hash equality alone.
-/// Production uses `NameDedup` (`StringContext`). Tests may inject a colliding hasher via
-/// `NameDedupWith` to prove identity stays byte equality under forced collisions.
+/// First-wins name set for indexing. Discarding a record requires full-string equality,
+/// even when different names produce the same hash.
 ///
 /// FAI stores stable keys in a child arena. `.zfi` stores offsets into `name_blob` so
 /// deduplication and output share one name copy.
@@ -64,10 +62,10 @@ pub fn NameDedupWith(comptime Context: type) type {
     return struct {
         map: std.HashMap([]const u8, void, Context, std.hash_map.default_max_load_percentage),
         key_arena: ?std.heap.ArenaAllocator = null,
-        /// When set, `.zfi` dedup stores `NameBlobRef` keys into this blob (not `map`).
+        // When set, `.zfi` dedup stores `NameBlobRef` keys into this blob (not `map`).
         name_blob: ?*std.ArrayList(u8) = null,
         ref_map: ?BlobRefMap = null,
-        /// After a successful first-seen `observe` in blob mode, the embedded span.
+        // After a successful first-seen `observe` in blob mode, the embedded span.
         last_offset: u32 = 0,
         last_len: u16 = 0,
 
@@ -113,7 +111,7 @@ pub fn NameDedupWith(comptime Context: type) type {
             };
         }
 
-        /// `.zfi`: one catalog in `blob` for both dedup and embedded names.
+        // `.zfi`: one catalog in `blob` for both dedup and embedded names.
         fn initOwningBlob(allocator: std.mem.Allocator, blob: *std.ArrayList(u8)) Self {
             return .{
                 .map = std.HashMap([]const u8, void, Context, std.hash_map.default_max_load_percentage).init(allocator),
@@ -146,7 +144,7 @@ pub fn NameDedupWith(comptime Context: type) type {
             self.name_blob = null;
         }
 
-        /// Returns true when `name` was already observed (caller should skip the record).
+        // Returns true when `name` was already observed (caller should skip the record).
         pub fn observe(self: *Self, name: []const u8) !bool {
             if (self.name_blob) |blob| {
                 var rm = &(self.ref_map orelse return error.OutOfMemory);
@@ -213,8 +211,8 @@ const LineMetrics = struct {
     line_bytes: u32 = 0,
     is_uniform_width: bool = true,
     line_count: u64 = 0,
-    /// First base line: every content byte was a base (no trailing space/tab) and the
-    /// on-wire separator was LF or CRLF. Needed so `AAAA \\n` is not treated as CRLF-dense.
+    // First base line: every content byte was a base (no trailing space/tab) and the
+    // on-wire separator was LF or CRLF. Needed so `AAAA \\n` is not treated as CRLF-dense.
     first_content_dense: bool = false,
 };
 
@@ -376,8 +374,8 @@ const LineMetricsBuilder = struct {
     pending_actual_bytes: u32 = 0,
     pending_content_len: u32 = 0,
     have_pending: bool = false,
-    /// Blank seen after at least one base line; applied only when another base line follows.
-    /// Trailing blanks before EOF or the next header do not change record geometry.
+    // Blank seen after at least one base line; applied only when another base line follows.
+    // Trailing blanks before EOF or the next header do not change record geometry.
     blank_after_bases: bool = false,
 
     fn ingestLine(self: *LineMetricsBuilder, bases: u32, actual_bytes: u32, has_lf: bool, content_len: u32) void {
@@ -547,12 +545,12 @@ pub fn scanZfiData(
     allocator: std.mem.Allocator,
 ) !ZfiIndex {
     var r = std.Io.Reader.fixed(data);
-    var read_buf: [index_read_buffer_size]u8 = undefined;
+    var read_buf: [INDEX_READ_BUFFER_SIZE]u8 = undefined;
     return scanZfiReader(&r, &read_buf, enable_dedup, allocator);
 }
 
-/// Single on-disk `.zfi` serialization path:
-/// header, records, side tables, name blob, `ZFID` source identity, `ZFNM` footer.
+// Single on-disk `.zfi` serialization path:
+// header, records, side tables, name blob, `ZFID` source identity, `ZFNM` footer.
 fn writeZfiIndex(
     writer: *std.Io.Writer,
     index: *const ZfiIndex,
@@ -1027,8 +1025,8 @@ fn processChunkBytes(
                 }
 
                 const fragment = data[i..name_end];
-                if (state.name.items.len > max_index_name_len or
-                    fragment.len > max_index_name_len - state.name.items.len)
+                if (state.name.items.len > MAX_INDEX_NAME_LEN or
+                    fragment.len > MAX_INDEX_NAME_LEN - state.name.items.len)
                 {
                     return error.HeaderTooLong;
                 }
@@ -1347,7 +1345,7 @@ pub fn scanFaiData(
     allocator: std.mem.Allocator,
 ) !u32 {
     var r = std.Io.Reader.fixed(data);
-    var read_buf: [index_read_buffer_size]u8 = undefined;
+    var read_buf: [INDEX_READ_BUFFER_SIZE]u8 = undefined;
     return scanFaiReader(&r, &read_buf, writer, .{ .enable_dedup = enable_dedup }, allocator);
 }
 
@@ -1371,7 +1369,7 @@ pub fn runIndex(
     const allocator = std.heap.page_allocator;
 
     var io_buf: [FILE_IO_BUF_SIZE]u8 = undefined;
-    var read_buf: [index_read_buffer_size]u8 = undefined;
+    var read_buf: [INDEX_READ_BUFFER_SIZE]u8 = undefined;
     var file_reader = file.reader(io, &io_buf);
 
     if (options.emit_fai) {
@@ -1464,11 +1462,6 @@ pub fn runIndex(
     std.debug.print("wrote {s} ({d} sequences)\n", .{ zfi_path, zfi_index.records.items.len });
 }
 
-/// Returns whether data begins with a FASTA header marker.
-pub fn validateFasta(data: []const u8) bool {
-    return data.len > 0 and data[0] == '>';
-}
-
 test "stride block validation matches scalar for structural mutations" {
     const line_bases: u32 = 4;
     const line_count = 520;
@@ -1520,20 +1513,33 @@ test "stride block validation matches scalar for structural mutations" {
 
 test "FAI suffix formatter matches std.fmt at field boundaries" {
     const cases = [_]IndexRecord{
-        .{ .seq_len = 0, .seq_offset = 0, .line_bases = 0, .line_bytes = 0 },
         .{
+            .name_offset = 0,
+            .name_len = 0,
+            .seq_len = 0,
+            .seq_offset = 0,
+            .line_bases = 0,
+            .line_bytes = 0,
+        },
+        .{
+            .name_offset = 0,
+            .name_len = 0,
             .seq_len = std.math.maxInt(u64),
             .seq_offset = std.math.maxInt(u64),
             .line_bases = std.math.maxInt(u32),
             .line_bytes = std.math.maxInt(u32),
         },
         .{
+            .name_offset = 0,
+            .name_len = 0,
             .seq_len = 0,
             .seq_offset = std.math.maxInt(u64),
             .line_bases = 0,
             .line_bytes = std.math.maxInt(u32),
         },
         .{
+            .name_offset = 0,
+            .name_len = 0,
             .seq_len = std.math.maxInt(u64),
             .seq_offset = 0,
             .line_bases = std.math.maxInt(u32),
@@ -1542,7 +1548,7 @@ test "FAI suffix formatter matches std.fmt at field boundaries" {
     };
 
     for (cases) |rec| {
-        var actual_buf: [128]u8 = undefined;
+        var actual_buf: [FAI_SUFFIX_BUFFER_SIZE]u8 = undefined;
         const actual = formatFaiSuffix(&actual_buf, rec);
         var expected_buf: [128]u8 = undefined;
         const expected = try std.fmt.bufPrint(
@@ -1584,6 +1590,30 @@ test "initial FASTA validation is an explicit scan option" {
             std.testing.allocator,
         ),
     );
+}
+
+test "name deduplication remains exact under hash collisions" {
+    const CollisionContext = struct {
+        pub fn hash(_: @This(), _: []const u8) u64 {
+            return 0;
+        }
+
+        pub fn eql(_: @This(), a: []const u8, b: []const u8) bool {
+            return std.mem.eql(u8, a, b);
+        }
+    };
+    const CollidingDedup = NameDedupWith(CollisionContext);
+    const names = [_][]const u8{ "alpha", "beta", "alpha", "gamma", "beta" };
+    var seen = CollidingDedup.init(std.testing.allocator);
+    defer seen.deinit();
+
+    var kept: usize = 0;
+    for (names) |name| {
+        if (!(try seen.observe(name))) kept += 1;
+    }
+
+    try std.testing.expectEqual(@as(usize, 3), kept);
+    try std.testing.expectEqual(@as(usize, 3), seen.map.count());
 }
 
 test "reader failures map to SourceReadFailed" {

--- a/src/indexer.zig
+++ b/src/indexer.zig
@@ -19,22 +19,17 @@ const ZFI_MAGIC = index_format.ZFI_MAGIC;
 const SIMD_CHUNK_SIZE = 32;
 const SimdVec = @Vector(SIMD_CHUNK_SIZE, u8);
 const STRIDE_VECTOR_LEN = std.simd.suggestVectorLength(u8) orelse 1;
-// Processes 256 lines per proof batch without additional storage.
 const STRIDE_VALIDATION_BLOCK_LINES = 256;
-// The input payload occupies this fixed stack buffer regardless of FASTA size.
 pub const INDEX_READ_BUFFER_SIZE = 1 * 1024 * 1024;
 const FILE_IO_BUF_SIZE = 8 * 1024;
-// Each output and replay stage uses one fixed stack buffer of this size.
 const INDEX_OUTPUT_BUFFER_SIZE = 64 * 1024;
-// Output paths longer than this fail without allocating from sequence-derived input.
-const INDEX_PATH_BUFFER_SIZE = 4096;
+const INDEX_PATH_BUFFER_SIZE = std.Io.Dir.max_path_bytes;
 // Catalogs start modestly and grow with records or names, never sequence payload bytes.
 const ZFI_INITIAL_RECORD_CAPACITY = 4096;
 const DEDUP_INITIAL_CAPACITY: u32 = 16384;
 const FAI_SPOOL_NAME_BUFFER_SIZE = 64;
 const FAI_U64_DECIMAL_DIGITS = 20;
 const FAI_SUFFIX_BUFFER_SIZE = 4 * (1 + FAI_U64_DECIMAL_DIGITS) + 1;
-// Exclusive creation retries only random name collisions within one directory.
 const FAI_SPOOL_CREATE_ATTEMPTS = 16;
 pub const MAX_INDEX_NAME_LEN = std.math.maxInt(u16);
 
@@ -51,14 +46,9 @@ pub const IndexOptions = struct {
 };
 
 // Offset into a name blob for `.zfi` catalog dedup (one store for map and output).
-const NameBlobRef = struct { off: u32, len: u32 };
+const NameBlobRef = struct { offset: u32, len: u32 };
 
-/// First-wins name set for indexing. Discarding a record requires full-string equality,
-/// even when different names produce the same hash.
-///
-/// FAI stores stable keys in a child arena. `.zfi` stores offsets into `name_blob` so
-/// deduplication and output share one name copy.
-pub fn NameDedupWith(comptime Context: type) type {
+fn NameDedupWith(comptime Context: type) type {
     return struct {
         map: std.HashMap([]const u8, void, Context, std.hash_map.default_max_load_percentage),
         key_arena: ?std.heap.ArenaAllocator = null,
@@ -72,14 +62,14 @@ pub fn NameDedupWith(comptime Context: type) type {
         const BlobHashContext = struct {
             blob: *std.ArrayList(u8),
             pub fn hash(self: @This(), key: NameBlobRef) u64 {
-                return std.hash_map.hashString(self.blob.items[key.off..][0..key.len]);
+                return std.hash_map.hashString(self.blob.items[key.offset..][0..key.len]);
             }
             pub fn eql(self: @This(), a: NameBlobRef, b: NameBlobRef) bool {
                 if (a.len != b.len) return false;
                 return std.mem.eql(
                     u8,
-                    self.blob.items[a.off..][0..a.len],
-                    self.blob.items[b.off..][0..b.len],
+                    self.blob.items[a.offset..][0..a.len],
+                    self.blob.items[b.offset..][0..b.len],
                 );
             }
         };
@@ -98,7 +88,7 @@ pub fn NameDedupWith(comptime Context: type) type {
             }
             pub fn eql(self: @This(), name: []const u8, ref: NameBlobRef) bool {
                 if (name.len != ref.len) return false;
-                return std.mem.eql(u8, name, self.blob.items[ref.off..][0..ref.len]);
+                return std.mem.eql(u8, name, self.blob.items[ref.offset..][0..ref.len]);
             }
         };
 
@@ -147,11 +137,11 @@ pub fn NameDedupWith(comptime Context: type) type {
         // Returns true when `name` was already observed (caller should skip the record).
         pub fn observe(self: *Self, name: []const u8) !bool {
             if (self.name_blob) |blob| {
-                var rm = &(self.ref_map orelse return error.OutOfMemory);
+                var rm = &(self.ref_map orelse unreachable);
                 const lookup = SliceLookup{ .blob = blob };
                 const gop = try rm.getOrPutAdapted(name, lookup);
                 if (gop.found_existing) {
-                    self.last_offset = gop.key_ptr.off;
+                    self.last_offset = gop.key_ptr.offset;
                     self.last_len = @intCast(gop.key_ptr.len);
                     return true;
                 }
@@ -160,12 +150,12 @@ pub fn NameDedupWith(comptime Context: type) type {
                     _ = rm.removeByPtr(gop.key_ptr);
                     return err;
                 };
-                gop.key_ptr.* = .{ .off = off, .len = @intCast(name.len) };
+                gop.key_ptr.* = .{ .offset = off, .len = @intCast(name.len) };
                 self.last_offset = off;
                 self.last_len = @intCast(name.len);
                 return false;
             }
-            const arena = &(self.key_arena orelse return error.OutOfMemory);
+            const arena = &(self.key_arena orelse unreachable);
             const gop = try self.map.getOrPut(name);
             if (gop.found_existing) return true;
             // Replace the temporary lookup key with an arena-owned copy (stable until deinit).
@@ -179,6 +169,8 @@ pub fn NameDedupWith(comptime Context: type) type {
     };
 }
 
+/// First-wins name set whose decisions use full-string equality despite hash collisions.
+/// FAI owns stable keys in a child arena; `.zfi` shares names with its output blob.
 pub const NameDedup = NameDedupWith(std.hash_map.StringContext);
 
 /// One parsed FASTA record passed to reader emit callbacks.
@@ -572,7 +564,6 @@ fn writeZfiIndex(
     try writer.writeAll(&index_format.encodeZfiNameFooter(index.name_blob.items.len));
 }
 
-/// Writes a `ZfiIndex` to a `.zfi` file via `writeZfiIndex`.
 pub fn writeZfiIndexFile(
     io: std.Io,
     path: []const u8,
@@ -589,7 +580,7 @@ pub fn writeZfiIndexFile(
     try file_fw.flush();
 }
 
-/// Serializes a `ZfiIndex` with the same bytes as `writeZfiIndexFile`.
+/// Caller owns the returned production-layout bytes.
 pub fn zfiIndexToBytes(
     index: *const ZfiIndex,
     source_size: u64,
@@ -853,7 +844,7 @@ const ChunkParseState = struct {
         self.pending_pre_lf_ends_with_cr = false;
     }
 
-    fn appendPendingFragment(self: *ChunkParseState, fragment: []const u8, fragment_file_offset: u64) void {
+    fn appendPendingFragment(self: *ChunkParseState, fragment: []const u8, fragment_file_offset: u64) !void {
         if (!self.in_pending_line) {
             self.in_pending_line = true;
             self.pending_line_bases = 0;
@@ -862,9 +853,14 @@ const ChunkParseState = struct {
             self.pending_pre_lf_ends_with_cr = false;
             self.pending_line_file_offset = fragment_file_offset;
         }
-        self.pending_line_bases += countBasesInLineSlice(fragment, 0, fragment.len);
-        self.pending_line_bytes += @intCast(fragment.len);
-        self.pending_pre_lf_bytes = self.pending_line_bytes;
+        const fragment_bases = countBasesInLineSlice(fragment, 0, fragment.len);
+        const next_bases = std.math.add(u32, self.pending_line_bases, fragment_bases) catch
+            return error.SequenceLineTooLong;
+        const next_bytes = std.math.add(u32, self.pending_line_bytes, @intCast(fragment.len)) catch
+            return error.SequenceLineTooLong;
+        self.pending_line_bases = next_bases;
+        self.pending_line_bytes = next_bytes;
+        self.pending_pre_lf_bytes = next_bytes;
         if (fragment.len > 0) {
             self.pending_pre_lf_ends_with_cr = fragment[fragment.len - 1] == '\r';
         }
@@ -872,6 +868,9 @@ const ChunkParseState = struct {
 
     fn commitPendingLine(self: *ChunkParseState, has_lf: bool) !void {
         if (!self.in_pending_line and self.pending_line_bytes == 0) return;
+        if (!has_lf and self.pending_line_bytes == std.math.maxInt(u32)) {
+            return error.SequenceLineTooLong;
+        }
         if (self.pending_line_bases > 0) self.noteSeqOffset(self.pending_line_file_offset);
         var content_len = if (has_lf) self.pending_pre_lf_bytes else self.pending_line_bytes;
         if (content_len > 0 and self.pending_pre_lf_ends_with_cr) {
@@ -989,12 +988,13 @@ fn processChunkBytes(
     if (state.in_pending_line) {
         const nl = findNextNewline(data, 0, data.len);
         if (nl >= data.len) {
-            state.appendPendingFragment(data, file_offset);
+            try state.appendPendingFragment(data, file_offset);
             return;
         }
 
-        state.appendPendingFragment(data[0..nl], file_offset);
-        state.pending_line_bytes += 1;
+        try state.appendPendingFragment(data[0..nl], file_offset);
+        state.pending_line_bytes = std.math.add(u32, state.pending_line_bytes, 1) catch
+            return error.SequenceLineTooLong;
         try state.commitPendingLine(true);
         i = nl + 1;
     }
@@ -1082,7 +1082,7 @@ fn processChunkBytes(
             if (data.len - i < line_bytes) {
                 // A partial chunk has no complete line when LF is absent.
                 if (findNextNewline(data, i, data.len) >= data.len) {
-                    state.appendPendingFragment(
+                    try state.appendPendingFragment(
                         data[i..],
                         file_offset + @as(u64, @intCast(i)),
                     );
@@ -1094,7 +1094,7 @@ fn processChunkBytes(
         const line_start = i;
         const nl = findNextNewline(data, i, data.len);
         if (nl >= data.len) {
-            state.appendPendingFragment(
+            try state.appendPendingFragment(
                 data[line_start..],
                 file_offset + @as(u64, @intCast(line_start)),
             );
@@ -1390,6 +1390,7 @@ pub fn runIndex(
             allocator,
         ) catch |err| switch (err) {
             error.HeaderTooLong,
+            error.SequenceLineTooLong,
             error.NotFasta,
             error.NonUniformFai,
             error.FaiSpoolWriteFailed,
@@ -1426,12 +1427,7 @@ pub fn runIndex(
     const zfi_path = std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{path}) catch
         return error.OutputPathTooLong;
 
-    var zfi_tmp_buf: [INDEX_PATH_BUFFER_SIZE]u8 = undefined;
-    const zfi_tmp_path = std.fmt.bufPrint(&zfi_tmp_buf, "{s}.zfi.tmp", .{path}) catch
-        return error.OutputPathTooLong;
-
     const cwd = std.Io.Dir.cwd();
-    cwd.deleteFile(io, zfi_tmp_path) catch {};
 
     var zfi_index = scanZfiReaderWithOptions(
         &file_reader.interface,
@@ -1439,7 +1435,12 @@ pub fn runIndex(
         .{ .enable_dedup = options.enable_dedup, .require_initial_header = true },
         allocator,
     ) catch |err| switch (err) {
-        error.HeaderTooLong, error.NotFasta, error.SourceReadFailed, error.OutOfMemory => return err,
+        error.HeaderTooLong,
+        error.SequenceLineTooLong,
+        error.NotFasta,
+        error.SourceReadFailed,
+        error.OutOfMemory,
+        => return err,
         error.MissingSideTable => return error.ProcessingFailed,
         else => return error.ProcessingFailed,
     };
@@ -1447,22 +1448,25 @@ pub fn runIndex(
 
     if (zfi_index.records.items.len == 0) return error.NoValidSequences;
 
+    const source_mtime_ns = index_format.timestampToNs(stat.mtime) catch return error.UnsupportedTimestamp;
+    var atomic_file = cwd.createFileAtomic(io, zfi_path, .{ .replace = true }) catch
+        return error.ZfiWriteFailed;
+    defer atomic_file.deinit(io);
+
+    var out_buf: [INDEX_OUTPUT_BUFFER_SIZE]u8 = undefined;
+    var file_fw = atomic_file.file.writer(io, &out_buf);
+    writeZfiIndex(&file_fw.interface, &zfi_index, stat.size, source_mtime_ns) catch
+        return error.ZfiWriteFailed;
+    file_fw.flush() catch return error.ZfiWriteFailed;
+
     if (!try sourcePathUnchanged(io, path, stat)) return error.SourceChanged;
 
-    writeZfiIndexFile(io, zfi_tmp_path, &zfi_index, stat.size, index_format.timestampToNs(stat.mtime)) catch {
-        cwd.deleteFile(io, zfi_tmp_path) catch {};
-        return error.ZfiWriteFailed;
-    };
-
-    cwd.rename(zfi_tmp_path, cwd, zfi_path, io) catch {
-        cwd.deleteFile(io, zfi_tmp_path) catch {};
-        return error.ZfiFinalizeFailed;
-    };
+    atomic_file.replace(io) catch return error.ZfiFinalizeFailed;
 
     std.debug.print("wrote {s} ({d} sequences)\n", .{ zfi_path, zfi_index.records.items.len });
 }
 
-test "stride block validation matches scalar for structural mutations" {
+test "[property] - [stride scanner]: matches scalar structural boundaries" {
     const line_bases: u32 = 4;
     const line_count = 520;
     const target_line = 256;
@@ -1511,7 +1515,7 @@ test "stride block validation matches scalar for structural mutations" {
     }
 }
 
-test "FAI suffix formatter matches std.fmt at field boundaries" {
+test "[property] - [FAI formatter]: matches standard formatting at integer boundaries" {
     const cases = [_]IndexRecord{
         .{
             .name_offset = 0,
@@ -1561,7 +1565,7 @@ test "FAI suffix formatter matches std.fmt at field boundaries" {
     }
 }
 
-test "initial FASTA validation is an explicit scan option" {
+test "[unit] - [FASTA scanner]: gates initial-header validation by option" {
     const data = "not-fasta\n";
     var read_buf: [4]u8 = undefined;
     var output = std.Io.Writer.Allocating.init(std.testing.allocator);
@@ -1592,7 +1596,33 @@ test "initial FASTA validation is an explicit scan option" {
     );
 }
 
-test "name deduplication remains exact under hash collisions" {
+test "[failure] - [FASTA scanner]: rejects sequence lines above u32 geometry" {
+    var state = ChunkParseState{
+        .allocator = std.testing.allocator,
+        .in_pending_line = true,
+        .pending_line_bases = std.math.maxInt(u32),
+    };
+    try std.testing.expectError(error.SequenceLineTooLong, state.appendPendingFragment("A", 0));
+
+    state.pending_line_bases = 0;
+    state.pending_line_bytes = std.math.maxInt(u32);
+    const Ctx = struct {
+        fn emit(_: *@This(), _: FastaRecordEmit) !void {
+            unreachable;
+        }
+    };
+    var ctx = Ctx{};
+    var record_count: u32 = 0;
+    try std.testing.expectError(
+        error.SequenceLineTooLong,
+        processChunkBytes(&state, "\n", 0, null, null, &ctx, Ctx.emit, &record_count),
+    );
+
+    state.pending_line_bases = 1;
+    try std.testing.expectError(error.SequenceLineTooLong, state.commitPendingLine(false));
+}
+
+test "[property] - [name deduplication]: remains exact under hash collisions" {
     const CollisionContext = struct {
         pub fn hash(_: @This(), _: []const u8) u64 {
             return 0;
@@ -1616,7 +1646,7 @@ test "name deduplication remains exact under hash collisions" {
     try std.testing.expectEqual(@as(usize, 3), seen.map.count());
 }
 
-test "reader failures map to SourceReadFailed" {
+test "[failure] - [FASTA scanner]: maps reader failures to SourceReadFailed" {
     var reader: std.Io.Reader = .failing;
     var read_buf: [4]u8 = undefined;
     var output = std.Io.Writer.Allocating.init(std.testing.allocator);
@@ -1634,7 +1664,7 @@ test "reader failures map to SourceReadFailed" {
     );
 }
 
-test "FAI writer failures map to FaiSpoolWriteFailed" {
+test "[failure] - [FAI scanner]: maps writer failures to FaiSpoolWriteFailed" {
     var reader = std.Io.Reader.fixed(">seq\nA\n");
     var read_buf: [4]u8 = undefined;
     var writer: std.Io.Writer = .failing;
@@ -1651,41 +1681,46 @@ test "FAI writer failures map to FaiSpoolWriteFailed" {
     );
 }
 
-test "FAI spools use independent exclusive files and clean up" {
+test "[integration] - [FAI spool]: uses exclusive files and cleans them" {
     var tmp = std.testing.tmpDir(.{ .iterate = true });
     defer tmp.cleanup();
 
-    var first = tryCreateFaiSpool(std.testing.io, tmp.dir, false) orelse
-        return error.TestUnexpectedResult;
-    var second = tryCreateFaiSpool(std.testing.io, tmp.dir, false) orelse {
-        first.deinit(std.testing.io);
-        return error.TestUnexpectedResult;
-    };
-    try std.testing.expect(!std.mem.eql(
-        u8,
-        first.name[0..first.name_len],
-        second.name[0..second.name_len],
-    ));
+    {
+        var first = tryCreateFaiSpool(std.testing.io, tmp.dir, false) orelse
+            return error.TestUnexpectedResult;
+        defer first.deinit(std.testing.io);
+        var second = tryCreateFaiSpool(std.testing.io, tmp.dir, false) orelse
+            return error.TestUnexpectedResult;
+        defer second.deinit(std.testing.io);
 
-    first.deinit(std.testing.io);
-    second.deinit(std.testing.io);
+        try std.testing.expect(!std.mem.eql(
+            u8,
+            first.name[0..first.name_len],
+            second.name[0..second.name_len],
+        ));
+    }
+
     var entries = tmp.dir.iterate();
     try std.testing.expectEqual(null, try entries.next(std.testing.io));
 }
 
-test "source metadata check observes path replacement" {
+test "[integration] - [source identity]: detects path replacement" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
 
-    const original = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
-    try std.Io.File.writeStreamingAll(original, std.testing.io, ">seq\nAAAA\n");
-    const before = try original.stat(std.testing.io);
-    original.close(std.testing.io);
+    const before = blk: {
+        const original = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+        defer original.close(std.testing.io);
+        try std.Io.File.writeStreamingAll(original, std.testing.io, ">seq\nAAAA\n");
+        break :blk try original.stat(std.testing.io);
+    };
 
     try tmp.dir.rename("source.fa", tmp.dir, "old.fa", std.testing.io);
-    const replacement = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
-    try std.Io.File.writeStreamingAll(replacement, std.testing.io, ">seq\nA\n");
-    replacement.close(std.testing.io);
+    {
+        const replacement = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+        defer replacement.close(std.testing.io);
+        try std.Io.File.writeStreamingAll(replacement, std.testing.io, ">seq\nA\n");
+    }
 
     var path_buf: [128]u8 = undefined;
     const source_path = try std.fmt.bufPrint(

--- a/src/indexer.zig
+++ b/src/indexer.zig
@@ -1308,8 +1308,8 @@ fn sourceMetadataMatches(before: std.Io.File.Stat, after: std.Io.File.Stat) bool
     return before.size == after.size and before.mtime.nanoseconds == after.mtime.nanoseconds;
 }
 
-fn sourcePathUnchanged(io: std.Io, path: []const u8, before: std.Io.File.Stat) !bool {
-    const after = std.Io.Dir.cwd().statFile(io, path, .{}) catch |err| switch (err) {
+fn sourcePathUnchanged(io: std.Io, dir: std.Io.Dir, path: []const u8, before: std.Io.File.Stat) !bool {
+    const after = dir.statFile(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return error.SourceStatFailed,
     };
@@ -1402,7 +1402,7 @@ pub fn runIndex(
         tmp_fw.interface.flush() catch return error.FaiSpoolWriteFailed;
         if (record_count == 0) return error.NoValidSequences;
 
-        if (!try sourcePathUnchanged(io, path, stat)) return error.SourceChanged;
+        if (!try sourcePathUnchanged(io, std.Io.Dir.cwd(), path, stat)) return error.SourceChanged;
 
         const tmp_size = (spool.file.stat(io) catch return error.FaiSpoolReadFailed).size;
         var offset: u64 = 0;
@@ -1459,7 +1459,7 @@ pub fn runIndex(
         return error.ZfiWriteFailed;
     file_fw.flush() catch return error.ZfiWriteFailed;
 
-    if (!try sourcePathUnchanged(io, path, stat)) return error.SourceChanged;
+    if (!try sourcePathUnchanged(io, cwd, path, stat)) return error.SourceChanged;
 
     atomic_file.replace(io) catch return error.ZfiFinalizeFailed;
 
@@ -1722,11 +1722,5 @@ test "[integration] - [source identity]: detects path replacement" {
         try std.Io.File.writeStreamingAll(replacement, std.testing.io, ">seq\nA\n");
     }
 
-    var path_buf: [128]u8 = undefined;
-    const source_path = try std.fmt.bufPrint(
-        &path_buf,
-        ".zig-cache/tmp/{s}/source.fa",
-        .{tmp.sub_path},
-    );
-    try std.testing.expect(!try sourcePathUnchanged(std.testing.io, source_path, before));
+    try std.testing.expect(!try sourcePathUnchanged(std.testing.io, tmp.dir, "source.fa", before));
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -13,12 +13,6 @@ pub const getter = @import("getter.zig");
 pub const stats = @import("stats.zig");
 pub const validator = @import("validator.zig");
 
-// --- Re-exports for tests ---
-pub const IndexRecord = index_format.IndexRecord;
-pub const ZfiHeader = index_format.ZfiHeader;
-pub const ZFI_MAGIC = index_format.ZFI_MAGIC;
-pub const validateFasta = indexer.validateFasta;
-
 const printErrorAndExit = index_format.printErrorAndExit;
 
 const VERSION = "0.3.1";
@@ -126,7 +120,7 @@ fn printUsageAndExit() noreturn {
     std.process.exit(1);
 }
 
-/// Positional argv tokens must not start with `-`. Known flags are matched earlier.
+// Positional argv tokens must not start with `-`. Known flags are matched earlier.
 fn rejectUnknownOption(arg: []const u8) void {
     if (arg.len > 0 and arg[0] == '-') {
         printErrorAndExit("error: unknown option: {s}\n", .{arg});
@@ -205,9 +199,7 @@ pub fn main(init: std.process.Init.Minimal) void {
     }
 }
 
-// ============================================================================
-// Subcommand: index
-// ============================================================================
+// --- Index command ---
 
 fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.Iterator) void {
     var emit_fai = false;
@@ -227,6 +219,9 @@ fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.It
             enable_dedup = true;
         } else {
             rejectUnknownOption(arg);
+            if (fasta_path != null) {
+                printErrorAndExit("error: index accepts exactly one FASTA path\n", .{});
+            }
             fasta_path = arg;
         }
     }
@@ -247,7 +242,7 @@ fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.It
         error.NotFasta => printErrorAndExit("error: not a FASTA file: {s}\n", .{path}),
         error.HeaderTooLong => printErrorAndExit(
             "error: sequence name exceeds {d} bytes: {s}\n",
-            .{ indexer.max_index_name_len, path },
+            .{ indexer.MAX_INDEX_NAME_LEN, path },
         ),
         error.NonUniformFai => printErrorAndExit(
             "error: cannot emit .fai for non-uniform sequence layout; run 'z-fasta index' (default) to write .zfi\n",
@@ -288,9 +283,7 @@ fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.It
     };
 }
 
-// ============================================================================
-// Subcommand: get
-// ============================================================================
+// --- Get command ---
 
 fn runGetCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     var fasta_path: ?[]const u8 = null;
@@ -387,30 +380,7 @@ fn runGetCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     });
 }
 
-test "parseTransformFlags returns requested orientation" {
-    const rc = try parseTransformFlags(true, false, false, false);
-    try std.testing.expect(rc.orientation.reverse);
-    try std.testing.expect(rc.orientation.complement);
-
-    const complement_only = try parseTransformFlags(false, true, false, true);
-    try std.testing.expect(!complement_only.orientation.reverse);
-    try std.testing.expect(complement_only.orientation.complement);
-    try std.testing.expect(complement_only.annotate_transform);
-
-    const reverse_only = try parseTransformFlags(false, false, true, false);
-    try std.testing.expect(reverse_only.orientation.reverse);
-    try std.testing.expect(!reverse_only.orientation.complement);
-}
-
-test "parseTransformFlags rejects conflicting transform flags" {
-    try std.testing.expectError(error.ConflictingTransformFlags, parseTransformFlags(true, true, false, false));
-    try std.testing.expectError(error.ConflictingTransformFlags, parseTransformFlags(true, false, true, false));
-    try std.testing.expectError(error.ConflictingTransformFlags, parseTransformFlags(false, true, true, false));
-}
-
-// ============================================================================
-// Subcommand: stats
-// ============================================================================
+// --- Stats command ---
 
 fn runStatsCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     var fasta_path: ?[]const u8 = null;
@@ -420,6 +390,9 @@ fn runStatsCmd(io: std.Io, args: *std.process.Args.Iterator) void {
             printHelpAndExit(io);
         } else {
             rejectUnknownOption(arg);
+            if (fasta_path != null) {
+                printErrorAndExit("error: stats accepts exactly one FASTA path\n", .{});
+            }
             fasta_path = arg;
         }
     }
@@ -431,9 +404,7 @@ fn runStatsCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     stats.runStats(std.heap.page_allocator, io, path);
 }
 
-// ============================================================================
-// Subcommand: validate
-// ============================================================================
+// --- Validate command ---
 
 fn runValidateCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     var fasta_path: ?[]const u8 = null;
@@ -486,6 +457,12 @@ fn runValidateCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     if (saw_summary and !saw_json) {
         printErrorAndExit("error: validate --summary requires --json\n", .{});
     }
+    if (options.fix_format_only and !options.fix) {
+        printErrorAndExit("error: validate --fix-format-only requires --fix\n", .{});
+    }
+    if (options.output_path != null and !options.fix) {
+        printErrorAndExit("error: validate -o requires --fix\n", .{});
+    }
 
     const path = fasta_path orelse {
         printErrorAndExit("error: usage: z-fasta validate [options] <file.fasta>\n", .{});
@@ -508,4 +485,33 @@ fn parsePositiveUsize(raw: []const u8, comptime flag: []const u8) usize {
         printErrorAndExit("error: {s} requires a positive integer\n", .{flag});
     }
     return parsed;
+}
+
+test "transform flags select the requested orientation" {
+    const rc = try parseTransformFlags(true, false, false, false);
+    const complement_only = try parseTransformFlags(false, true, false, true);
+    const reverse_only = try parseTransformFlags(false, false, true, false);
+
+    try std.testing.expect(rc.orientation.reverse);
+    try std.testing.expect(rc.orientation.complement);
+    try std.testing.expect(!complement_only.orientation.reverse);
+    try std.testing.expect(complement_only.orientation.complement);
+    try std.testing.expect(complement_only.annotate_transform);
+    try std.testing.expect(reverse_only.orientation.reverse);
+    try std.testing.expect(!reverse_only.orientation.complement);
+}
+
+test "transform flags reject conflicting modes" {
+    const conflicts = [_][3]bool{
+        .{ true, true, false },
+        .{ true, false, true },
+        .{ false, true, true },
+    };
+
+    for (conflicts) |flags| {
+        try std.testing.expectError(
+            error.ConflictingTransformFlags,
+            parseTransformFlags(flags[0], flags[1], flags[2], false),
+        );
+    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,12 +1,8 @@
 //! CLI entry and subcommand dispatcher for `index`, `get`, `stats`, and `validate`.
-//!
-//! Re-exports core modules for tests. Argument parsing, usage text, and routing live here;
-//! indexing, extraction, stats, and validation logic live in the sibling modules.
 
 const std = @import("std");
 const builtin = @import("builtin");
 
-// --- Module imports ---
 pub const index_format = @import("index_format.zig");
 pub const indexer = @import("indexer.zig");
 pub const getter = @import("getter.zig");
@@ -93,7 +89,12 @@ const ParsedTransformFlags = struct {
     annotate_transform: bool,
 };
 
-fn parseTransformFlags(rc: bool, complement_only: bool, reverse_only: bool, annotate_transform: bool) ParseTransformFlagsError!ParsedTransformFlags {
+fn parseTransformFlags(
+    rc: bool,
+    complement_only: bool,
+    reverse_only: bool,
+    annotate_transform: bool,
+) ParseTransformFlagsError!ParsedTransformFlags {
     var selected: usize = 0;
     if (rc) selected += 1;
     if (complement_only) selected += 1;
@@ -244,6 +245,10 @@ fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.It
             "error: sequence name exceeds {d} bytes: {s}\n",
             .{ indexer.MAX_INDEX_NAME_LEN, path },
         ),
+        error.SequenceLineTooLong => printErrorAndExit(
+            "error: sequence line exceeds the index format limit: {s}\n",
+            .{path},
+        ),
         error.NonUniformFai => printErrorAndExit(
             "error: cannot emit .fai for non-uniform sequence layout; run 'z-fasta index' (default) to write .zfi\n",
             .{},
@@ -269,6 +274,10 @@ fn runIndex(io: std.Io, environ: std.process.Environ, args: *std.process.Args.It
         error.StdoutFlushFailed => printErrorAndExit("error: failed to flush FAI stdout\n", .{}),
         error.SourceChanged => printErrorAndExit(
             "error: source changed while indexing: {s}\n",
+            .{path},
+        ),
+        error.UnsupportedTimestamp => printErrorAndExit(
+            "error: source modification time predates the Unix epoch: {s}\n",
             .{path},
         ),
         error.OutputPathTooLong => printErrorAndExit("error: path too long\n", .{}),
@@ -487,7 +496,7 @@ fn parsePositiveUsize(raw: []const u8, comptime flag: []const u8) usize {
     return parsed;
 }
 
-test "transform flags select the requested orientation" {
+test "[unit] - [get transform flags]: selects the requested orientation" {
     const rc = try parseTransformFlags(true, false, false, false);
     const complement_only = try parseTransformFlags(false, true, false, true);
     const reverse_only = try parseTransformFlags(false, false, true, false);
@@ -501,11 +510,12 @@ test "transform flags select the requested orientation" {
     try std.testing.expect(!reverse_only.orientation.complement);
 }
 
-test "transform flags reject conflicting modes" {
+test "[failure] - [get transform flags]: rejects conflicting modes" {
     const conflicts = [_][3]bool{
         .{ true, true, false },
         .{ true, false, true },
         .{ false, true, true },
+        .{ true, true, true },
     };
 
     for (conflicts) |flags| {
@@ -516,7 +526,7 @@ test "transform flags reject conflicting modes" {
     }
 }
 
-test "[cli] - [dispatch]: invalid invocations print help on stderr" {
+test "[cli] - [dispatch]: writes help and rejects missing or unknown commands" {
     const zfasta_bin = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
     const allocator = std.testing.allocator;
     var threaded = std.Io.Threaded.init(allocator, .{});
@@ -535,7 +545,7 @@ test "[cli] - [dispatch]: invalid invocations print help on stderr" {
         else => return error.ChildProcessFailed,
     }
     try std.testing.expectEqual(@as(usize, 0), help.stderr.len);
-    try std.testing.expect(help.stdout.len > 0);
+    try std.testing.expectEqualStrings(USAGE, help.stdout);
 
     const cases = [_][]const []const u8{
         &.{zfasta_bin},

--- a/src/main.zig
+++ b/src/main.zig
@@ -378,7 +378,7 @@ fn runGetCmd(io: std.Io, args: *std.process.Args.Iterator) void {
     else
         .{ .positional = region_buf[0..region_count] };
 
-    getter.runGetWithOptions(io, path, .{
+    getter.runGetWithOptions(std.heap.page_allocator, io, path, .{
         .source = source,
         .honor_strand = honor_strand,
         .summary = summary,
@@ -428,7 +428,7 @@ fn runStatsCmd(io: std.Io, args: *std.process.Args.Iterator) void {
         printErrorAndExit("error: usage: z-fasta stats <file.fasta>\n", .{});
     };
 
-    stats.runStats(io, path);
+    stats.runStats(std.heap.page_allocator, io, path);
 }
 
 // ============================================================================

--- a/src/main.zig
+++ b/src/main.zig
@@ -515,3 +515,47 @@ test "transform flags reject conflicting modes" {
         );
     }
 }
+
+test "[cli] - [dispatch]: invalid invocations print help on stderr" {
+    const zfasta_bin = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+    const allocator = std.testing.allocator;
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    const io = threaded.io();
+
+    const help = try std.process.run(allocator, io, .{
+        .argv = &.{ zfasta_bin, "--help" },
+        .stdout_limit = .limited(64 * 1024),
+        .stderr_limit = .limited(64 * 1024),
+    });
+    defer allocator.free(help.stdout);
+    defer allocator.free(help.stderr);
+    switch (help.term) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.ChildProcessFailed,
+    }
+    try std.testing.expectEqual(@as(usize, 0), help.stderr.len);
+    try std.testing.expect(help.stdout.len > 0);
+
+    const cases = [_][]const []const u8{
+        &.{zfasta_bin},
+        &.{ zfasta_bin, "index" },
+        &.{ zfasta_bin, "not-a-command" },
+    };
+    for (cases) |argv| {
+        const result = try std.process.run(allocator, io, .{
+            .argv = argv,
+            .stdout_limit = .limited(64 * 1024),
+            .stderr_limit = .limited(64 * 1024),
+        });
+        defer allocator.free(result.stdout);
+        defer allocator.free(result.stderr);
+
+        switch (result.term) {
+            .exited => |code| try std.testing.expectEqual(@as(u8, 1), code),
+            else => return error.ChildProcessFailed,
+        }
+        try std.testing.expectEqual(@as(usize, 0), result.stdout.len);
+        try std.testing.expectEqualStrings(help.stdout, result.stderr);
+    }
+}

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -3,9 +3,11 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
+/// Read-only mapped bytes aligned for platform mapping APIs. The corresponding
+/// `MemoryMap` owns the lifetime.
 pub const MappedBytes = []align(std.heap.page_size_min) const u8;
 
-/// Maps a file read-only without prefaulting pages on POSIX.
+/// Maps exactly `len` nonzero bytes read-only without prefaulting pages on POSIX.
 ///
 /// Zig 0.16's Windows `NtCreateSection` path requires `.populate = true`; false
 /// produces `STATUS_INVALID_PARAMETER`. Call `MemoryMap.destroy` when finished.
@@ -28,7 +30,7 @@ pub fn adviseSequential(memory: MappedBytes) void {
     ) catch {};
 }
 
-test "read-only mapping exposes file contents" {
+test "[integration] - [read-only mapping]: exposes file contents" {
     const contents = "mapped bytes";
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
@@ -39,5 +41,7 @@ test "read-only mapping exposes file contents" {
 
     var map = try mapFileReadOnly(std.testing.io, file, contents.len);
     defer map.destroy(std.testing.io);
+    adviseSequential(map.memory);
+
     try std.testing.expectEqualStrings(contents, map.memory);
 }

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -21,11 +21,9 @@ pub fn mapFileReadOnly(io: std.Io, file: std.Io.File, len: usize) error{MmapFail
 pub fn adviseSequential(memory: MappedBytes) void {
     if (comptime builtin.os.tag == .windows) return;
     if (memory.len == 0) return;
-    const len = std.mem.alignBackward(usize, memory.len, std.heap.page_size_min);
-    if (len == 0) return;
     std.posix.madvise(
-        @alignCast(@constCast(memory.ptr)),
-        len,
+        @constCast(memory.ptr),
+        memory.len,
         std.posix.MADV.SEQUENTIAL,
     ) catch {};
 }

--- a/src/platform.zig
+++ b/src/platform.zig
@@ -1,74 +1,45 @@
-//! Portable file mapping and memory advice.
-//!
-//! Core modules must not call `std.posix.mmap` / `munmap` / `madvise` directly.
-//! Mapping goes through `std.Io.File.MemoryMap` (native Windows path included).
-//! Advice is a best-effort optimization: real on Linux/macOS, no-op on Windows.
+//! Cross-platform policy for read-only file mapping and memory advice.
 
 const std = @import("std");
 const builtin = @import("builtin");
 
-pub const mapped_align = std.heap.page_size_min;
-pub const MappedBytes = []align(mapped_align) const u8;
+pub const MappedBytes = []align(std.heap.page_size_min) const u8;
 
-pub const Advice = enum {
-    sequential,
-    random,
-    dont_need,
-};
-
-/// Owns a whole-file mapping.
+/// Maps a file read-only without prefaulting pages on POSIX.
 ///
-/// On POSIX, `.populate = false` keeps pages lazy. On Windows, Zig 0.16's
-/// `NtCreateSection` path passes `{ .COMMIT = populate }` as allocation
-/// attributes; `populate = false` yields attributes 0 and
-/// `STATUS_INVALID_PARAMETER` (0xc00000f4), so Windows must use `populate = true`.
-pub const FileView = struct {
-    map: std.Io.File.MemoryMap,
-
-    pub fn mapFile(io: std.Io, file: std.Io.File, len: usize) MapError!FileView {
-        const map = file.createMemoryMap(io, .{
-            .len = len,
-            .protection = .{ .read = true, .write = false },
-            .populate = builtin.os.tag == .windows,
-        }) catch return error.MmapFailed;
-        return .{ .map = map };
-    }
-
-    pub fn bytes(self: *const FileView) MappedBytes {
-        return self.map.memory;
-    }
-
-    pub fn destroy(self: *FileView, io: std.Io) void {
-        self.map.destroy(io);
-    }
-};
-
-pub const MapError = error{MmapFailed};
-
-/// Optional access hint for a mapped region. No-op on Windows.
-pub fn advise(memory: []const u8, kind: Advice) void {
-    if (comptime builtin.os.tag == .windows) return;
-    if (memory.len == 0) return;
-    const len = std.mem.alignBackward(usize, memory.len, mapped_align);
-    if (len == 0) return;
-    const madv: u32 = switch (kind) {
-        .sequential => std.posix.MADV.SEQUENTIAL,
-        .random => std.posix.MADV.RANDOM,
-        .dont_need => std.posix.MADV.DONTNEED,
-    };
-    std.posix.madvise(@alignCast(@constCast(memory.ptr)), len, madv) catch {};
+/// Zig 0.16's Windows `NtCreateSection` path requires `.populate = true`; false
+/// produces `STATUS_INVALID_PARAMETER`. Call `MemoryMap.destroy` when finished.
+pub fn mapFileReadOnly(io: std.Io, file: std.Io.File, len: usize) error{MmapFailed}!std.Io.File.MemoryMap {
+    return file.createMemoryMap(io, .{
+        .len = len,
+        .protection = .{ .read = true, .write = false },
+        .populate = builtin.os.tag == .windows,
+    }) catch error.MmapFailed;
 }
 
-/// Release (or hint release of) pages covering `[start, end_exclusive)`.
-pub fn releaseSpan(memory: []const u8, start: usize, end_exclusive: usize) void {
+/// Hints that a mapped region will be read sequentially. No-op on Windows.
+pub fn adviseSequential(memory: MappedBytes) void {
     if (comptime builtin.os.tag == .windows) return;
-    if (start >= end_exclusive or memory.len == 0) return;
-    const drop_start = std.mem.alignBackward(usize, start, mapped_align);
-    const drop_end = @min(memory.len, std.mem.alignForward(usize, end_exclusive, mapped_align));
-    if (drop_end <= drop_start) return;
+    if (memory.len == 0) return;
+    const len = std.mem.alignBackward(usize, memory.len, std.heap.page_size_min);
+    if (len == 0) return;
     std.posix.madvise(
-        @alignCast(@constCast(memory.ptr + drop_start)),
-        drop_end - drop_start,
-        std.posix.MADV.DONTNEED,
+        @alignCast(@constCast(memory.ptr)),
+        len,
+        std.posix.MADV.SEQUENTIAL,
     ) catch {};
+}
+
+test "read-only mapping exposes file contents" {
+    const contents = "mapped bytes";
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const file = try tmp.dir.createFile(std.testing.io, "input", .{ .read = true });
+    defer file.close(std.testing.io);
+    try std.Io.File.writeStreamingAll(file, std.testing.io, contents);
+
+    var map = try mapFileReadOnly(std.testing.io, file, contents.len);
+    defer map.destroy(std.testing.io);
+    try std.testing.expectEqualStrings(contents, map.memory);
 }

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -334,7 +334,6 @@ fn writeReport(
     }
 }
 
-/// Run the stats command.
 pub fn runStats(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) void {
     var idx = index_format.loadIndexForStats(allocator, io, fasta_path);
     defer idx.deinit();
@@ -637,31 +636,51 @@ pub fn detectType(counts: *const [256]u64, total: u64) SequenceType {
     return .protein;
 }
 
+fn testIndexRecord(seq_offset: u64, seq_len: u64, line_bases: u32, line_bytes: u32) IndexRecord {
+    return .{
+        .name_offset = 0,
+        .name_len = 0,
+        .seq_offset = seq_offset,
+        .seq_len = seq_len,
+        .line_bases = line_bases,
+        .line_bytes = line_bytes,
+    };
+}
+
 test "recordsInSeqOffsetOrder detects sorted and unsorted offsets" {
     const sorted = [_]IndexRecord{
-        .{ .seq_offset = 10, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
-        .{ .seq_offset = 20, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
-        .{ .seq_offset = 30, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
+        testIndexRecord(10, 1, 1, 2),
+        testIndexRecord(20, 1, 1, 2),
+        testIndexRecord(30, 1, 1, 2),
     };
     try std.testing.expect(recordsInSeqOffsetOrder(&sorted));
 
     const unsorted = [_]IndexRecord{
-        .{ .seq_offset = 30, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
-        .{ .seq_offset = 10, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
+        testIndexRecord(30, 1, 1, 2),
+        testIndexRecord(10, 1, 1, 2),
     };
     try std.testing.expect(!recordsInSeqOffsetOrder(&unsorted));
 }
 
-test "countCompositionSlice tallies composition and lowercase" {
-    var comp: CompositionStats = .{};
+test "composition SIMD matches scalar counts at every tail length" {
+    var data: [512]u8 = undefined;
+    for (&data, 0..) |*byte, i| byte.* = @truncate(i);
 
-    countCompositionSlice("ACGTacgtNN", &comp);
+    for (0..data.len + 1) |len| {
+        var expected: [256]u64 = .{0} ** 256;
+        var expected_lowercase: u64 = 0;
+        for (data[0..len]) |byte| {
+            expected[byte] += 1;
+            if (byte >= 'a' and byte <= 'z') expected_lowercase += 1;
+        }
+        var comp: CompositionStats = .{};
 
-    try std.testing.expectEqual(@as(u64, 10), comp.total_bases);
-    try std.testing.expectEqual(@as(u64, 4), comp.lowercase_count);
-    try std.testing.expectEqual(@as(u64, 1), comp.counts['A']);
-    try std.testing.expectEqual(@as(u64, 1), comp.counts['a']);
-    try std.testing.expectEqual(@as(u64, 2), comp.counts['N']);
+        countCompositionSlice(data[0..len], &comp);
+
+        try std.testing.expectEqual(@as(u64, @intCast(len)), comp.total_bases);
+        try std.testing.expectEqual(expected_lowercase, comp.lowercase_count);
+        try std.testing.expectEqualSlices(u64, &expected, &comp.counts);
+    }
 }
 
 test "bounded uniform reader handles LF CRLF and missing final newline" {
@@ -672,11 +691,11 @@ test "bounded uniform reader handles LF CRLF and missing final newline" {
     const cases = [_]Case{
         .{
             .bytes = "prefixACGT\nacgt\nNN",
-            .record = .{ .seq_offset = 6, .seq_len = 10, .line_bases = 4, .line_bytes = 5 },
+            .record = testIndexRecord(6, 10, 4, 5),
         },
         .{
             .bytes = "xACGT\r\nacgt\r\nNN\r\nsuffix",
-            .record = .{ .seq_offset = 1, .seq_len = 10, .line_bases = 4, .line_bytes = 6 },
+            .record = testIndexRecord(1, 10, 4, 6),
         },
     };
     const buffer_sizes = [_]usize{ 1, 2, 3, 4, 5, 6, 7, 15, 16, 17, 32, 33 };
@@ -684,7 +703,7 @@ test "bounded uniform reader handles LF CRLF and missing final newline" {
     for (cases) |case| {
         var tmp = std.testing.tmpDir(.{});
         defer tmp.cleanup();
-        const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+        const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{ .read = true });
         defer file.close(std.testing.io);
         try std.Io.File.writeStreamingAll(file, std.testing.io, case.bytes);
         for (buffer_sizes) |buffer_size| {
@@ -712,7 +731,7 @@ test "bounded readers exclude headers gaps and adjacent record bytes" {
     const buffer_sizes = [_]usize{ 3, 32 };
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+    const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{ .read = true });
     defer file.close(std.testing.io);
     try std.Io.File.writeStreamingAll(file, std.testing.io, bytes);
     for (buffer_sizes) |buffer_size| {
@@ -727,12 +746,12 @@ test "bounded readers exclude headers gaps and adjacent record bytes" {
 
         try scanUniformRecord(
             &reader,
-            .{ .seq_offset = 5, .seq_len = 4, .line_bases = 2, .line_bytes = 3 },
+            testIndexRecord(5, 4, 2, 3),
             &comp,
         );
         try scanUniformRecord(
             &reader,
-            .{ .seq_offset = 16, .seq_len = 2, .line_bases = 2, .line_bytes = 3 },
+            testIndexRecord(16, 2, 2, 3),
             &comp,
         );
 
@@ -755,7 +774,7 @@ test "bounded side-table reader coalesces only adjacent owned spans" {
     const buffer_sizes = [_]usize{ 1, 2, 3, 4, 5, 6, 7 };
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
-    const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
+    const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{ .read = true });
     defer file.close(std.testing.io);
     try std.Io.File.writeStreamingAll(file, std.testing.io, bytes);
     for (buffer_sizes) |buffer_size| {
@@ -776,7 +795,7 @@ test "bounded side-table reader coalesces only adjacent owned spans" {
     }
 }
 
-test "bounded reader rejects geometry beyond the FASTA boundary" {
+test "bounded reader rejects invalid uniform geometry" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
@@ -790,15 +809,17 @@ test "bounded reader rejects geometry beyond the FASTA boundary" {
         .file_size = 4,
         .buffer = &storage,
     };
+    const invalid = [_]IndexRecord{
+        testIndexRecord(0, 1, 0, 0),
+        testIndexRecord(0, 1, 2, 1),
+        testIndexRecord(0, 5, 5, 6),
+        testIndexRecord(std.math.maxInt(u64), 1, 1, 1),
+        testIndexRecord(0, std.math.maxInt(u64), 1, std.math.maxInt(u32)),
+    };
 
-    try std.testing.expectError(
-        error.CorruptGeometry,
-        scanUniformRecord(
-            &reader,
-            .{ .seq_offset = 0, .seq_len = 5, .line_bases = 5, .line_bytes = 6 },
-            &comp,
-        ),
-    );
+    for (invalid) |record| {
+        try std.testing.expectError(error.CorruptGeometry, scanUniformRecord(&reader, record, &comp));
+    }
 }
 
 test "median arithmetic is overflow safe" {
@@ -809,8 +830,8 @@ test "median arithmetic is overflow safe" {
 
 test "length total overflow is rejected" {
     const records = [_]IndexRecord{
-        .{ .seq_len = std.math.maxInt(u64), .line_bases = 1, .line_bytes = 2 },
-        .{ .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
+        testIndexRecord(0, std.math.maxInt(u64), 1, 2),
+        testIndexRecord(0, 1, 1, 2),
     };
     var lengths: [2]u64 = undefined;
 
@@ -820,8 +841,8 @@ test "length total overflow is rejected" {
 test "auN accumulation and formatting use u128" {
     const length: u64 = 1 << 32;
     const records = [_]IndexRecord{
-        .{ .seq_len = length, .line_bases = 1, .line_bytes = 2 },
-        .{ .seq_len = length, .line_bases = 1, .line_bytes = 2 },
+        testIndexRecord(0, length, 1, 2),
+        testIndexRecord(0, length, 1, 2),
     };
     var lengths: [2]u64 = undefined;
     const summary = try summarizeLengths(&records, &lengths);
@@ -852,7 +873,7 @@ test "fixed decimals use exact half-away rounding" {
 
 test "report writing propagates a full destination" {
     const records = [_]IndexRecord{
-        .{ .seq_len = 4, .line_bases = 4, .line_bytes = 5 },
+        testIndexRecord(0, 4, 4, 5),
     };
     const summary = LengthSummary{
         .total_symbols = 4,

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -27,8 +27,6 @@ pub const GET_TYPE_SAMPLE_BASES: u64 = 256;
 /// Bases sampled across the file for validation alphabet selection.
 pub const VALIDATE_TYPE_SAMPLE_BASES: u64 = 100_000;
 
-// --- Stats computation ---
-
 const CompositionStats = struct {
     counts: [256]u64 = .{0} ** 256,
     total_bases: u64 = 0,
@@ -334,6 +332,8 @@ fn writeReport(
     }
 }
 
+/// Loads indexed FASTA statistics, writes the exact report to stdout, and exits
+/// through the shared CLI diagnostic path on failure.
 pub fn runStats(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) void {
     var idx = index_format.loadIndexForStats(allocator, io, fasta_path);
     defer idx.deinit();
@@ -379,7 +379,18 @@ pub fn runStats(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8
         .fai => ".fai",
     };
 
-    writeReport(writer, fasta_path, index_ext, idx.fasta_size, records, summary, shortest_name, longest_name, &comp, composition) catch {
+    writeReport(
+        writer,
+        fasta_path,
+        index_ext,
+        idx.fasta_size,
+        records,
+        summary,
+        shortest_name,
+        longest_name,
+        &comp,
+        composition,
+    ) catch {
         printErrorAndExit("error: write failed\n", .{});
     };
     stdout_fw.flush() catch {
@@ -474,7 +485,11 @@ fn scanUniformRecord(reader: *BoundedFastaReader, rec: IndexRecord, comp: *Compo
     }
 }
 
-fn scanSideTableRecord(reader: *BoundedFastaReader, lines: []const SideTableLine, comp: *CompositionStats) ScanError!void {
+fn scanSideTableRecord(
+    reader: *BoundedFastaReader,
+    lines: []const SideTableLine,
+    comp: *CompositionStats,
+) ScanError!void {
     if (lines.len == 0) return error.CorruptGeometry;
 
     var line_index: usize = 0;
@@ -602,16 +617,15 @@ fn countCompositionSlice(data: []const u8, comp: *CompositionStats) void {
     }
 }
 
-/// Detect if sequences are nucleotide or protein from composition counts.
+/// Detects whether represented sequence counts are nucleotide or protein.
 ///
 /// Shared by stats (full-file counts), GET (per-record sample), and validate
 /// (prefix sample). Threshold: nucleotide if IUPAC nuc letters are strictly
-/// more than 90% of counted bases (`nuc * 10 > total * 9`).
+/// more than 90% of counted bases (`nuc * 10 > total * 9`). The caller supplies
+/// `total` for the same sample represented by `counts`. Empty samples are nucleotide.
 pub fn detectType(counts: *const [256]u64, total: u64) SequenceType {
     if (total == 0) return .nucleotide;
 
-    // Sum the full IUPAC nucleotide alphabet (case-insensitive):
-    // A C G T U R Y S W K M B D H V N
     const nuc_count = counts['A'] + counts['a'] +
         counts['C'] + counts['c'] +
         counts['G'] + counts['g'] +
@@ -647,7 +661,7 @@ fn testIndexRecord(seq_offset: u64, seq_len: u64, line_bases: u32, line_bytes: u
     };
 }
 
-test "recordsInSeqOffsetOrder detects sorted and unsorted offsets" {
+test "[unit] - [stats scan order]: detects sorted and unsorted offsets" {
     const sorted = [_]IndexRecord{
         testIndexRecord(10, 1, 1, 2),
         testIndexRecord(20, 1, 1, 2),
@@ -662,7 +676,7 @@ test "recordsInSeqOffsetOrder detects sorted and unsorted offsets" {
     try std.testing.expect(!recordsInSeqOffsetOrder(&unsorted));
 }
 
-test "composition SIMD matches scalar counts at every tail length" {
+test "[property] - [stats composition]: SIMD matches scalar counts at every tail length" {
     var data: [512]u8 = undefined;
     for (&data, 0..) |*byte, i| byte.* = @truncate(i);
 
@@ -683,7 +697,7 @@ test "composition SIMD matches scalar counts at every tail length" {
     }
 }
 
-test "bounded uniform reader handles LF CRLF and missing final newline" {
+test "[integration] - [stats composition]: scans uniform line-ending variants" {
     const Case = struct {
         bytes: []const u8,
         record: IndexRecord,
@@ -726,7 +740,7 @@ test "bounded uniform reader handles LF CRLF and missing final newline" {
     }
 }
 
-test "bounded readers exclude headers gaps and adjacent record bytes" {
+test "[integration] - [stats composition]: excludes bytes outside indexed spans" {
     const bytes = ">one\nAC\nGT\n>two\nTT\n";
     const buffer_sizes = [_]usize{ 3, 32 };
     var tmp = std.testing.tmpDir(.{});
@@ -764,7 +778,7 @@ test "bounded readers exclude headers gaps and adjacent record bytes" {
     }
 }
 
-test "bounded side-table reader coalesces only adjacent owned spans" {
+test "[integration] - [stats composition]: coalesces only adjacent side-table spans" {
     const bytes = "AC\nGT\nignored\nnn\r\n";
     const lines = [_]SideTableLine{
         .{ .base_start = 0, .byte_offset = 0, .line_bytes = 3, .line_bases = 2 },
@@ -795,7 +809,7 @@ test "bounded side-table reader coalesces only adjacent owned spans" {
     }
 }
 
-test "bounded reader rejects invalid uniform geometry" {
+test "[failure] - [stats composition]: rejects invalid uniform geometry" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();
     const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
@@ -822,13 +836,34 @@ test "bounded reader rejects invalid uniform geometry" {
     }
 }
 
-test "median arithmetic is overflow safe" {
+test "[failure] - [stats composition]: propagates positional read failure" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{ .read = true });
+    std.Io.File.writeStreamingAll(file, std.testing.io, "A") catch |err| {
+        file.close(std.testing.io);
+        return err;
+    };
+    file.close(std.testing.io);
+
+    var storage: [1]u8 = undefined;
+    var reader = BoundedFastaReader{
+        .io = std.testing.io,
+        .file = file,
+        .file_size = 1,
+        .buffer = &storage,
+    };
+
+    try std.testing.expectError(error.ReadFailed, reader.read(0, 1));
+}
+
+test "[edge] - [stats lengths]: computes a near-maximum median without overflow" {
     const near_max = [_]u64{ std.math.maxInt(u64) - 1, std.math.maxInt(u64) };
 
     try std.testing.expectEqual(std.math.maxInt(u64) - 1, medianSorted(&near_max));
 }
 
-test "length total overflow is rejected" {
+test "[failure] - [stats lengths]: rejects total-symbol overflow" {
     const records = [_]IndexRecord{
         testIndexRecord(0, std.math.maxInt(u64), 1, 2),
         testIndexRecord(0, 1, 1, 2),
@@ -838,7 +873,7 @@ test "length total overflow is rejected" {
     try std.testing.expectError(error.Overflow, summarizeLengths(&records, &lengths));
 }
 
-test "auN accumulation and formatting use u128" {
+test "[edge] - [stats lengths]: accumulates and formats auN above u64" {
     const length: u64 = 1 << 32;
     const records = [_]IndexRecord{
         testIndexRecord(0, length, 1, 2),
@@ -855,7 +890,7 @@ test "auN accumulation and formatting use u128" {
     try std.testing.expectEqualStrings("4294967296.00", writer.buffered());
 }
 
-test "fixed decimals use exact half-away rounding" {
+test "[unit] - [stats formatting]: rounds fixed decimals exactly" {
     var buffer: [64]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buffer);
     try writeFixedUnsigned(&writer, 100, 32, 2);
@@ -871,7 +906,7 @@ test "fixed decimals use exact half-away rounding" {
     try std.testing.expectEqualStrings("3.13 66.67 14.13 -0.938 0.000", writer.buffered());
 }
 
-test "report writing propagates a full destination" {
+test "[failure] - [stats report]: propagates a full destination" {
     const records = [_]IndexRecord{
         testIndexRecord(0, 4, 4, 5),
     };
@@ -912,9 +947,15 @@ test "report writing propagates a full destination" {
     );
 }
 
-test "composition categories cannot exceed indexed symbols" {
-    var comp: CompositionStats = .{ .total_bases = 4 };
-    comp.counts['A'] = 5;
+test "[failure] - [stats composition]: rejects categories above total symbols" {
+    const sequence_types = [_]SequenceType{ .nucleotide, .protein };
+    for (sequence_types) |sequence_type| {
+        var comp: CompositionStats = .{
+            .total_bases = 4,
+            .seq_type = sequence_type,
+        };
+        comp.counts['A'] = 5;
 
-    try std.testing.expectError(error.CompositionMismatch, summarizeComposition(&comp));
+        try std.testing.expectError(error.CompositionMismatch, summarizeComposition(&comp));
+    }
 }

--- a/src/stats.zig
+++ b/src/stats.zig
@@ -1,4 +1,7 @@
 //! Assembly and proteome statistics from indexed FASTA files.
+//!
+//! Length statistics come from index metadata. Type and composition use one
+//! descriptor-owned bounded read window over indexed sequence spans.
 
 const std = @import("std");
 const index_format = @import("index_format.zig");
@@ -15,17 +18,22 @@ const TailVec = @Vector(TAIL_CHUNK_SIZE, u8);
 const FINAL_CHUNK_SIZE = 4;
 const FinalVec = @Vector(FINAL_CHUNK_SIZE, u8);
 
-// ============================================================================
-// Stats computation
-// ============================================================================
-
+/// Sequence class shared by stats, GET transformation guards, and validation.
 pub const SequenceType = enum { nucleotide, protein };
 
+/// Bases sampled per record for GET transformation guards.
+pub const GET_TYPE_SAMPLE_BASES: u64 = 256;
+
+/// Bases sampled across the file for validation alphabet selection.
+pub const VALIDATE_TYPE_SAMPLE_BASES: u64 = 100_000;
+
+// --- Stats computation ---
+
 const CompositionStats = struct {
-    counts: [256]u64,
-    total_bases: u64,
-    seq_type: SequenceType,
-    lowercase_count: u64,
+    counts: [256]u64 = .{0} ** 256,
+    total_bases: u64 = 0,
+    seq_type: SequenceType = .nucleotide,
+    lowercase_count: u64 = 0,
 };
 
 const LengthSummary = struct {
@@ -52,7 +60,7 @@ const NucleotideSummary = struct {
 };
 
 const ProteinSummary = struct {
-    categories: [protein_fields.len]u64,
+    categories: [PROTEIN_FIELDS.len]u64,
     stop: u64,
     invalid: u64,
 };
@@ -67,7 +75,7 @@ const ProteinField = struct {
     code: u8,
 };
 
-const protein_fields = [_]ProteinField{
+const PROTEIN_FIELDS = [_]ProteinField{
     .{ .key = "a_alanine", .code = 'A' },
     .{ .key = "r_arginine", .code = 'R' },
     .{ .key = "n_asparagine", .code = 'N' },
@@ -141,6 +149,7 @@ fn summarizeLengths(records: []const IndexRecord, lengths: []u64) !LengthSummary
         if (l90 == 0 and seen >= threshold_90) {
             n90 = lengths[i];
             l90 = rank;
+            break;
         }
     }
 
@@ -220,9 +229,9 @@ fn summarizeComposition(comp: *const CompositionStats) !CompositionSummary {
         } };
     }
 
-    var categories: [protein_fields.len]u64 = undefined;
+    var categories: [PROTEIN_FIELDS.len]u64 = undefined;
     var assigned: u128 = 0;
-    for (protein_fields, 0..) |field, i| {
+    for (PROTEIN_FIELDS, 0..) |field, i| {
         categories[i] = countLetter(comp, field.code);
         assigned += categories[i];
     }
@@ -270,7 +279,7 @@ fn writeNucleotide(writer: *std.Io.Writer, summary: NucleotideSummary, comp: *co
 
 fn writeProtein(writer: *std.Io.Writer, summary: ProteinSummary, comp: *const CompositionStats) !void {
     try writer.writeAll("  type: protein\n  percent_denominator: total_symbols\n");
-    for (protein_fields, summary.categories) |field, count| {
+    for (PROTEIN_FIELDS, summary.categories) |field, count| {
         try writeCountPercent(writer, field.key, count, comp.total_bases);
     }
     try writeCountPercent(writer, "stop", summary.stop, comp.total_bases);
@@ -291,18 +300,31 @@ fn writeReport(
     composition: CompositionSummary,
 ) !void {
     try writer.print(
-        "File:\n  path: {s}\n  index: {s}{s}\n  size_bytes: {d}\n\n" ++
-            "Lengths:\n  indexed_records: {d}\n  total_symbols: {d}\n" ++
+        "File:\n  path: {s}\n  index: {s}{s}\n  size_bytes: {d}\n\n",
+        .{ fasta_path, fasta_path, index_extension, fasta_size },
+    );
+    try writer.print(
+        "Lengths:\n  indexed_records: {d}\n  total_symbols: {d}\n" ++
             "  shortest_length: {d}\n  shortest_name: {s}\n" ++
             "  longest_length: {d}\n  longest_name: {s}\n" ++
-            "  mean: {d}\n  q1: {d}\n  median: {d}\n  q3: {d}\n  range: {d}\n\n" ++
-            "Nx:\n  n50: {d}\n  l50: {d}\n  n90: {d}\n  l90: {d}\n  aun: ",
+            "  mean: {d}\n  q1: {d}\n  median: {d}\n  q3: {d}\n  range: {d}\n\n",
         .{
-            fasta_path,                              fasta_path,    index_extension,                        fasta_size,   records.len,  summary.total_symbols,
-            records[summary.shortest_index].seq_len, shortest_name, records[summary.longest_index].seq_len, longest_name, summary.mean, summary.q1,
-            summary.median,                          summary.q3,    summary.range,                          summary.n50,  summary.l50,  summary.n90,
-            summary.l90,
+            records.len,
+            summary.total_symbols,
+            records[summary.shortest_index].seq_len,
+            shortest_name,
+            records[summary.longest_index].seq_len,
+            longest_name,
+            summary.mean,
+            summary.q1,
+            summary.median,
+            summary.q3,
+            summary.range,
         },
+    );
+    try writer.print(
+        "Nx:\n  n50: {d}\n  l50: {d}\n  n90: {d}\n  l90: {d}\n  aun: ",
+        .{ summary.n50, summary.l50, summary.n90, summary.l90 },
     );
     try writeFixedUnsigned(writer, summary.aun_numerator, summary.total_symbols, 2);
     try writer.writeAll("\n\nComposition:\n");
@@ -313,30 +335,31 @@ fn writeReport(
 }
 
 /// Run the stats command.
-pub fn runStats(io: std.Io, fasta_path: []const u8) void {
-    var idx = index_format.loadIndexForStats(io, fasta_path);
-    defer idx.deinit(io);
+pub fn runStats(allocator: std.mem.Allocator, io: std.Io, fasta_path: []const u8) void {
+    var idx = index_format.loadIndexForStats(allocator, io, fasta_path);
+    defer idx.deinit();
 
     const records = idx.records;
-    const num_seqs = records.len;
+    const record_count = records.len;
 
-    if (num_seqs == 0) {
+    if (record_count == 0) {
         printErrorAndExit("error: no sequences in index\n", .{});
     }
 
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const lengths = allocator.alloc(u64, num_seqs) catch {
+    const lengths = allocator.alloc(u64, record_count) catch {
         printErrorAndExit("error: out of memory\n", .{});
     };
+    defer allocator.free(lengths);
     const summary = summarizeLengths(records, lengths) catch {
         printErrorAndExit("error: sequence length overflow\n", .{});
     };
-    const shortest_name = idx.getRecordName(summary.shortest_index);
-    const longest_name = idx.getRecordName(summary.longest_index);
-    const comp = scanComposition(&idx, allocator) catch |err| switch (err) {
+    const shortest_name = idx.recordName(summary.shortest_index) orelse {
+        printErrorAndExit("error: index does not retain the shortest record name\n", .{});
+    };
+    const longest_name = idx.recordName(summary.longest_index) orelse {
+        printErrorAndExit("error: index does not retain the longest record name\n", .{});
+    };
+    const comp = scanComposition(allocator, &idx) catch |err| switch (err) {
         error.OutOfMemory => printErrorAndExit("error: out of memory\n", .{}),
         error.ReadFailed => printErrorAndExit("error: failed to read FASTA\n", .{}),
         error.CorruptGeometry => printErrorAndExit("error: index sequence lengths do not match FASTA data\n", .{}),
@@ -367,27 +390,18 @@ pub fn runStats(io: std.Io, fasta_path: []const u8) void {
 
 const STATS_READ_BUFFER_BYTES: usize = 256 * 1024;
 
-const FastaSource = struct {
-    io: std.Io,
-    file: std.Io.File,
-    size: u64,
-};
-
-const StatsRecord = struct {
-    geometry: IndexRecord,
-    side_table: []const SideTableLine,
-};
-
 const ScanError = error{ OutOfMemory, ReadFailed, CorruptGeometry };
 
 const BoundedFastaReader = struct {
-    source: FastaSource,
+    io: std.Io,
+    file: std.Io.File,
+    file_size: u64,
     buffer: []u8,
     start: u64 = 0,
     len: usize = 0,
 
     fn read(self: *BoundedFastaReader, offset: u64, limit: u64) ScanError![]const u8 {
-        if (self.buffer.len == 0 or offset >= self.source.size or limit == 0) return error.CorruptGeometry;
+        if (self.buffer.len == 0 or offset >= self.file_size or limit == 0) return error.CorruptGeometry;
 
         const buffered_end = std.math.add(u64, self.start, self.len) catch return error.CorruptGeometry;
         if (offset >= self.start and offset < buffered_end) {
@@ -397,10 +411,10 @@ const BoundedFastaReader = struct {
             return self.buffer[relative..][0..take];
         }
 
-        const wanted: usize = @intCast(@min(@as(u64, self.buffer.len), self.source.size - offset));
+        const wanted: usize = @intCast(@min(@as(u64, self.buffer.len), self.file_size - offset));
         const got = std.Io.File.readPositionalAll(
-            self.source.file,
-            self.source.io,
+            self.file,
+            self.io,
             self.buffer[0..wanted],
             offset,
         ) catch return error.ReadFailed;
@@ -435,7 +449,7 @@ fn scanUniformRecord(reader: *BoundedFastaReader, rec: IndexRecord, comp: *Compo
     const last_offset = std.math.add(u64, line_offset, column) catch return error.CorruptGeometry;
     const span_len = std.math.add(u64, last_offset, 1) catch return error.CorruptGeometry;
     const span_end = std.math.add(u64, rec.seq_offset, span_len) catch return error.CorruptGeometry;
-    if (span_end > reader.source.size) return error.CorruptGeometry;
+    if (span_end > reader.file_size) return error.CorruptGeometry;
 
     var offset = rec.seq_offset;
     var line_pos: usize = 0;
@@ -452,7 +466,7 @@ fn scanUniformRecord(reader: *BoundedFastaReader, rec: IndexRecord, comp: *Compo
                 continue;
             }
             const bases = @min(data.len - pos, @as(usize, rec.line_bases) - line_pos);
-            countCompositionSlice(data[pos..][0..bases], &comp.counts, &comp.total_bases, &comp.lowercase_count);
+            countCompositionSlice(data[pos..][0..bases], comp);
             pos += bases;
             line_pos += bases;
             if (line_pos == rec.line_bytes) line_pos = 0;
@@ -476,7 +490,7 @@ fn scanSideTableRecord(reader: *BoundedFastaReader, lines: []const SideTableLine
             end = next_end;
             line_index += 1;
         }
-        if (end > reader.source.size) return error.CorruptGeometry;
+        if (end > reader.file_size) return error.CorruptGeometry;
 
         var offset = start;
         while (offset < end) {
@@ -487,34 +501,37 @@ fn scanSideTableRecord(reader: *BoundedFastaReader, lines: []const SideTableLine
     }
 }
 
-fn scanStatsRecord(reader: *BoundedFastaReader, record: StatsRecord, comp: *CompositionStats) ScanError!void {
-    if (record.geometry.seq_len == 0) return;
-    if (record.geometry.isUniformWidth()) {
-        try scanUniformRecord(reader, record.geometry, comp);
+fn scanRecord(
+    reader: *BoundedFastaReader,
+    rec: IndexRecord,
+    side_table: []const SideTableLine,
+    comp: *CompositionStats,
+) ScanError!void {
+    if (rec.seq_len == 0) return;
+    if (rec.isUniformWidth()) {
+        try scanUniformRecord(reader, rec, comp);
     } else {
-        try scanSideTableRecord(reader, record.side_table, comp);
+        try scanSideTableRecord(reader, side_table, comp);
     }
 }
 
-fn scanComposition(idx: *const LoadedIndex, allocator: std.mem.Allocator) ScanError!CompositionStats {
-    var comp = CompositionStats{
-        .counts = .{0} ** 256,
-        .total_bases = 0,
-        .seq_type = .nucleotide,
-        .lowercase_count = 0,
-    };
+fn scanComposition(allocator: std.mem.Allocator, idx: *const LoadedIndex) ScanError!CompositionStats {
+    var comp: CompositionStats = .{};
     var buffer: [STATS_READ_BUFFER_BYTES]u8 = undefined;
     var reader = BoundedFastaReader{
-        .source = .{ .io = idx.io, .file = idx.fasta_file, .size = idx.fasta_size },
+        .io = idx.io,
+        .file = idx.fasta_file,
+        .file_size = idx.fasta_size,
         .buffer = &buffer,
     };
 
     if (recordsInSeqOffsetOrder(idx.records)) {
         for (idx.records) |rec| {
-            try scanStatsRecord(&reader, .{ .geometry = rec, .side_table = idx.sideTableLines(rec) }, &comp);
+            try scanRecord(&reader, rec, idx.sideTableLines(rec), &comp);
         }
     } else {
         const indices = allocator.alloc(usize, idx.records.len) catch return error.OutOfMemory;
+        defer allocator.free(indices);
         for (indices, 0..) |*slot, i| slot.* = i;
         std.mem.sort(usize, indices, idx.records, struct {
             fn lessThan(records: []const IndexRecord, a: usize, b: usize) bool {
@@ -523,7 +540,7 @@ fn scanComposition(idx: *const LoadedIndex, allocator: std.mem.Allocator) ScanEr
         }.lessThan);
         for (indices) |rec_index| {
             const rec = idx.records[rec_index];
-            try scanStatsRecord(&reader, .{ .geometry = rec, .side_table = idx.sideTableLines(rec) }, &comp);
+            try scanRecord(&reader, rec, idx.sideTableLines(rec), &comp);
         }
     }
 
@@ -541,12 +558,7 @@ fn recordsInSeqOffsetOrder(records: []const IndexRecord) bool {
     return true;
 }
 
-fn countCompositionSlice(
-    data: []const u8,
-    counts: *[256]u64,
-    total_bases: *u64,
-    lowercase_count: *u64,
-) void {
+fn countCompositionSlice(data: []const u8, comp: *CompositionStats) void {
     const a_vec: SimdVec = @splat('a');
     const z_vec: SimdVec = @splat('z');
 
@@ -554,39 +566,39 @@ fn countCompositionSlice(
     while (pos + SIMD_CHUNK_SIZE <= data.len) {
         const chunk: SimdVec = data[pos..][0..SIMD_CHUNK_SIZE].*;
         inline for (0..SIMD_CHUNK_SIZE) |j| {
-            counts[chunk[j]] += 1;
+            comp.counts[chunk[j]] += 1;
         }
-        total_bases.* += SIMD_CHUNK_SIZE;
+        comp.total_bases += SIMD_CHUNK_SIZE;
         const lower_mask = (chunk >= a_vec) & (chunk <= z_vec);
-        lowercase_count.* += @popCount(@as(u32, @bitCast(lower_mask)));
+        comp.lowercase_count += @popCount(@as(u32, @bitCast(lower_mask)));
         pos += SIMD_CHUNK_SIZE;
     }
     while (pos + TAIL_CHUNK_SIZE <= data.len) {
         const chunk: TailVec = data[pos..][0..TAIL_CHUNK_SIZE].*;
         inline for (0..TAIL_CHUNK_SIZE) |j| {
-            counts[chunk[j]] += 1;
+            comp.counts[chunk[j]] += 1;
         }
-        total_bases.* += TAIL_CHUNK_SIZE;
+        comp.total_bases += TAIL_CHUNK_SIZE;
         const lower_mask = (chunk >= @as(TailVec, @splat('a'))) & (chunk <= @as(TailVec, @splat('z')));
-        lowercase_count.* += @popCount(@as(u8, @bitCast(lower_mask)));
+        comp.lowercase_count += @popCount(@as(u8, @bitCast(lower_mask)));
         pos += TAIL_CHUNK_SIZE;
     }
     while (pos + FINAL_CHUNK_SIZE <= data.len) {
         const chunk: FinalVec = data[pos..][0..FINAL_CHUNK_SIZE].*;
         inline for (0..FINAL_CHUNK_SIZE) |j| {
-            counts[chunk[j]] += 1;
+            comp.counts[chunk[j]] += 1;
         }
-        total_bases.* += FINAL_CHUNK_SIZE;
+        comp.total_bases += FINAL_CHUNK_SIZE;
         const lower_mask = (chunk >= @as(FinalVec, @splat('a'))) & (chunk <= @as(FinalVec, @splat('z')));
-        lowercase_count.* += @popCount(@as(u4, @bitCast(lower_mask)));
+        comp.lowercase_count += @popCount(@as(u4, @bitCast(lower_mask)));
         pos += FINAL_CHUNK_SIZE;
     }
     while (pos < data.len) : (pos += 1) {
         const byte = data[pos];
-        counts[byte] += 1;
-        total_bases.* += 1;
+        comp.counts[byte] += 1;
+        comp.total_bases += 1;
         if (byte >= 'a' and byte <= 'z') {
-            lowercase_count.* += 1;
+            comp.lowercase_count += 1;
         }
     }
 }
@@ -625,12 +637,6 @@ pub fn detectType(counts: *const [256]u64, total: u64) SequenceType {
     return .protein;
 }
 
-/// Bases sampled per record for GET `--rc` / `--complement-only` protein guard.
-pub const get_type_sample_bases: u64 = 256;
-
-/// Bases sampled across the file for validate alphabet selection.
-pub const validate_type_sample_bases: u64 = 100_000;
-
 test "recordsInSeqOffsetOrder detects sorted and unsorted offsets" {
     const sorted = [_]IndexRecord{
         .{ .seq_offset = 10, .seq_len = 1, .line_bases = 1, .line_bytes = 2 },
@@ -647,15 +653,15 @@ test "recordsInSeqOffsetOrder detects sorted and unsorted offsets" {
 }
 
 test "countCompositionSlice tallies composition and lowercase" {
-    var counts: [256]u64 = .{0} ** 256;
-    var total: u64 = 0;
-    var lowercase: u64 = 0;
-    countCompositionSlice("ACGTacgtNN", &counts, &total, &lowercase);
-    try std.testing.expectEqual(@as(u64, 10), total);
-    try std.testing.expectEqual(@as(u64, 4), lowercase);
-    try std.testing.expectEqual(@as(u64, 1), counts['A']);
-    try std.testing.expectEqual(@as(u64, 1), counts['a']);
-    try std.testing.expectEqual(@as(u64, 2), counts['N']);
+    var comp: CompositionStats = .{};
+
+    countCompositionSlice("ACGTacgtNN", &comp);
+
+    try std.testing.expectEqual(@as(u64, 10), comp.total_bases);
+    try std.testing.expectEqual(@as(u64, 4), comp.lowercase_count);
+    try std.testing.expectEqual(@as(u64, 1), comp.counts['A']);
+    try std.testing.expectEqual(@as(u64, 1), comp.counts['a']);
+    try std.testing.expectEqual(@as(u64, 2), comp.counts['N']);
 }
 
 test "bounded uniform reader handles LF CRLF and missing final newline" {
@@ -681,17 +687,15 @@ test "bounded uniform reader handles LF CRLF and missing final newline" {
         const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
         defer file.close(std.testing.io);
         try std.Io.File.writeStreamingAll(file, std.testing.io, case.bytes);
-        const source = FastaSource{ .io = std.testing.io, .file = file, .size = case.bytes.len };
-
         for (buffer_sizes) |buffer_size| {
-            var comp = CompositionStats{
-                .counts = .{0} ** 256,
-                .total_bases = 0,
-                .seq_type = .nucleotide,
-                .lowercase_count = 0,
-            };
+            var comp: CompositionStats = .{};
             var storage: [33]u8 = undefined;
-            var reader = BoundedFastaReader{ .source = source, .buffer = storage[0..buffer_size] };
+            var reader = BoundedFastaReader{
+                .io = std.testing.io,
+                .file = file,
+                .file_size = case.bytes.len,
+                .buffer = storage[0..buffer_size],
+            };
 
             try scanUniformRecord(&reader, case.record, &comp);
             try std.testing.expectEqual(@as(u64, 10), comp.total_bases);
@@ -711,17 +715,15 @@ test "bounded readers exclude headers gaps and adjacent record bytes" {
     const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
     defer file.close(std.testing.io);
     try std.Io.File.writeStreamingAll(file, std.testing.io, bytes);
-    const source = FastaSource{ .io = std.testing.io, .file = file, .size = bytes.len };
-
     for (buffer_sizes) |buffer_size| {
         var storage: [32]u8 = undefined;
-        var comp = CompositionStats{
-            .counts = .{0} ** 256,
-            .total_bases = 0,
-            .seq_type = .nucleotide,
-            .lowercase_count = 0,
+        var comp: CompositionStats = .{};
+        var reader = BoundedFastaReader{
+            .io = std.testing.io,
+            .file = file,
+            .file_size = bytes.len,
+            .buffer = storage[0..buffer_size],
         };
-        var reader = BoundedFastaReader{ .source = source, .buffer = storage[0..buffer_size] };
 
         try scanUniformRecord(
             &reader,
@@ -756,17 +758,15 @@ test "bounded side-table reader coalesces only adjacent owned spans" {
     const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
     defer file.close(std.testing.io);
     try std.Io.File.writeStreamingAll(file, std.testing.io, bytes);
-    const source = FastaSource{ .io = std.testing.io, .file = file, .size = bytes.len };
-
     for (buffer_sizes) |buffer_size| {
-        var comp = CompositionStats{
-            .counts = .{0} ** 256,
-            .total_bases = 0,
-            .seq_type = .nucleotide,
-            .lowercase_count = 0,
-        };
+        var comp: CompositionStats = .{};
         var storage: [7]u8 = undefined;
-        var reader = BoundedFastaReader{ .source = source, .buffer = storage[0..buffer_size] };
+        var reader = BoundedFastaReader{
+            .io = std.testing.io,
+            .file = file,
+            .file_size = bytes.len,
+            .buffer = storage[0..buffer_size],
+        };
 
         try scanSideTableRecord(&reader, &lines, &comp);
         try std.testing.expectEqual(@as(u64, 6), comp.total_bases);
@@ -782,15 +782,14 @@ test "bounded reader rejects geometry beyond the FASTA boundary" {
     const file = try tmp.dir.createFile(std.testing.io, "source.fa", .{});
     defer file.close(std.testing.io);
     try std.Io.File.writeStreamingAll(file, std.testing.io, "ACGT");
-    const source = FastaSource{ .io = std.testing.io, .file = file, .size = 4 };
     var storage: [2]u8 = undefined;
-    var comp = CompositionStats{
-        .counts = .{0} ** 256,
-        .total_bases = 0,
-        .seq_type = .nucleotide,
-        .lowercase_count = 0,
+    var comp: CompositionStats = .{};
+    var reader = BoundedFastaReader{
+        .io = std.testing.io,
+        .file = file,
+        .file_size = 4,
+        .buffer = &storage,
     };
-    var reader = BoundedFastaReader{ .source = source, .buffer = &storage };
 
     try std.testing.expectError(
         error.CorruptGeometry,
@@ -818,10 +817,29 @@ test "length total overflow is rejected" {
     try std.testing.expectError(error.Overflow, summarizeLengths(&records, &lengths));
 }
 
+test "auN accumulation and formatting use u128" {
+    const length: u64 = 1 << 32;
+    const records = [_]IndexRecord{
+        .{ .seq_len = length, .line_bases = 1, .line_bytes = 2 },
+        .{ .seq_len = length, .line_bases = 1, .line_bytes = 2 },
+    };
+    var lengths: [2]u64 = undefined;
+    const summary = try summarizeLengths(&records, &lengths);
+    try std.testing.expectEqual(@as(u64, 1) << 33, summary.total_symbols);
+    try std.testing.expectEqual(@as(u128, 1) << 65, summary.aun_numerator);
+
+    var buffer: [32]u8 = undefined;
+    var writer = std.Io.Writer.fixed(&buffer);
+    try writeFixedUnsigned(&writer, summary.aun_numerator, summary.total_symbols, 2);
+    try std.testing.expectEqualStrings("4294967296.00", writer.buffered());
+}
+
 test "fixed decimals use exact half-away rounding" {
     var buffer: [64]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buffer);
     try writeFixedUnsigned(&writer, 100, 32, 2);
+    try writer.writeByte(' ');
+    try writeFixedUnsigned(&writer, 200, 3, 2);
     try writer.writeByte(' ');
     try writeFixedUnsigned(&writer, 226, 16, 2);
     try writer.writeByte(' ');
@@ -829,7 +847,7 @@ test "fixed decimals use exact half-away rounding" {
     try writer.writeByte(' ');
     try writeFixedSigned(&writer, -1, 10_000, 3);
 
-    try std.testing.expectEqualStrings("3.13 14.13 -0.938 0.000", writer.buffered());
+    try std.testing.expectEqualStrings("3.13 66.67 14.13 -0.938 0.000", writer.buffered());
 }
 
 test "report writing propagates a full destination" {
@@ -851,12 +869,7 @@ test "report writing propagates a full destination" {
         .l90 = 1,
         .aun_numerator = 16,
     };
-    var comp = CompositionStats{
-        .counts = .{0} ** 256,
-        .total_bases = 4,
-        .seq_type = .nucleotide,
-        .lowercase_count = 0,
-    };
+    var comp: CompositionStats = .{ .total_bases = 4 };
     comp.counts['A'] = 4;
     var buffer: [1]u8 = undefined;
     var writer = std.Io.Writer.fixed(&buffer);
@@ -879,12 +892,7 @@ test "report writing propagates a full destination" {
 }
 
 test "composition categories cannot exceed indexed symbols" {
-    var comp = CompositionStats{
-        .counts = .{0} ** 256,
-        .total_bases = 4,
-        .seq_type = .nucleotide,
-        .lowercase_count = 0,
-    };
+    var comp: CompositionStats = .{ .total_bases = 4 };
     comp.counts['A'] = 5;
 
     try std.testing.expectError(error.CompositionMismatch, summarizeComposition(&comp));

--- a/src/validator.zig
+++ b/src/validator.zig
@@ -1,6 +1,6 @@
 //! FASTA structure, alphabet, and header validation with optional fix streaming.
 //!
-//! Events are capped (`max_validate_events`). JSON output escapes arbitrary header bytes.
+//! Events are capped (`MAX_VALIDATE_EVENTS`). JSON output escapes arbitrary header bytes.
 //! Shared sequence-type sampling uses `stats.detectType`.
 
 const std = @import("std");
@@ -18,12 +18,12 @@ const SimdVec = @Vector(SIMD_CHUNK_SIZE, u8);
 
 /// Hard cap on retained validate events. Further issues set `Summary.truncated`
 /// instead of growing an unbounded list.
-pub const max_validate_events: usize = 10_000;
+pub const MAX_VALIDATE_EVENTS: usize = 10_000;
 
 comptime {
     // Keep the validate help line in src/main.zig synchronized with this value.
-    if (max_validate_events != 10_000) {
-        @compileError("update validate help text for max_validate_events");
+    if (MAX_VALIDATE_EVENTS != 10_000) {
+        @compileError("update validate help text for MAX_VALIDATE_EVENTS");
     }
 }
 
@@ -101,6 +101,8 @@ pub const Kind = enum {
     }
 };
 
+const KIND_COUNT = @typeInfo(Kind).@"enum".fields.len;
+
 pub const ValidateEvent = struct {
     level: Level,
     kind: Kind,
@@ -123,8 +125,12 @@ pub const Summary = struct {
     header_count: usize = 0,
     error_count: usize = 0,
     warning_count: usize = 0,
-    /// True when more issues were found after `max_validate_events` were retained.
+    format_warning_count: usize = 0,
+    kind_counts: [KIND_COUNT]usize = .{0} ** KIND_COUNT,
+    /// True when more issues were found after `MAX_VALIDATE_EVENTS` were retained.
     truncated: bool = false,
+    /// Fix blocker found after event retention reached its cap.
+    truncated_fix_rejection: ?Kind = null,
 
     pub fn deinit(self: *Summary, allocator: std.mem.Allocator) void {
         self.events.deinit(allocator);
@@ -134,7 +140,7 @@ pub const Summary = struct {
 
 const WidthCount = struct {
     width: u32,
-    count: u32,
+    count: usize,
     first_order: usize,
 };
 
@@ -184,7 +190,10 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
     const data: []const u8 = if (stat.size == 0)
         &[_]u8{}
     else blk: {
-        fasta_map = platform.mapFileReadOnly(io, file, @intCast(stat.size)) catch {
+        const map_len = std.math.cast(usize, stat.size) orelse {
+            printErrorAndExit("error: failed to mmap file: {s}\n", .{fasta_path});
+        };
+        fasta_map = platform.mapFileReadOnly(io, file, map_len) catch {
             printErrorAndExit("error: failed to mmap file: {s}\n", .{fasta_path});
         };
         break :blk fasta_map.?.memory;
@@ -205,7 +214,9 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
         const output_path = options.output_path orelse {
             printErrorAndExit("error: validate --fix requires -o <output.fa>\n", .{});
         };
-        if (std.mem.eql(u8, fasta_path, output_path)) {
+        if (std.mem.eql(u8, fasta_path, output_path) or
+            outputResolvesToInput(io, file, output_path))
+        {
             printErrorAndExit("error: validate --fix will not overwrite input: {s}\n", .{fasta_path});
         }
         ensureFixAllowed(&summary, options);
@@ -231,12 +242,12 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
         if (!options.fix) {
             printErrorAndExit(
                 "error: validate stopped after {d} events; fix reported issues and re-run\n",
-                .{max_validate_events},
+                .{MAX_VALIDATE_EVENTS},
             );
         }
         std.debug.print(
             "warning: validate event list truncated at {d}; --fix output was still written\n",
-            .{max_validate_events},
+            .{MAX_VALIDATE_EVENTS},
         );
     }
 
@@ -250,8 +261,8 @@ pub fn validateData(allocator: std.mem.Allocator, data: []const u8, options: Opt
     };
     errdefer summary.deinit(allocator);
 
-    var seen_names = std.StringHashMap(usize).init(allocator);
-    defer seen_names.deinit();
+    var seen_names: std.StringHashMapUnmanaged(usize) = .empty;
+    defer seen_names.deinit(allocator);
 
     var type_counts: [256]u64 = .{0} ** 256;
     var type_total: u64 = 0;
@@ -353,16 +364,11 @@ pub fn exitCode(error_count: usize, warning_count: usize, strict: bool) u8 {
 pub fn exitCodeForOptions(summary: *const Summary, options: Options) u8 {
     if (!options.fix) return exitCode(summary.error_count, summary.warning_count, options.strict);
 
-    var remaining_errors: usize = 0;
-    var remaining_warnings: usize = 0;
-    for (summary.events.items) |event| {
-        if (isFixedByFormatRewrite(event.kind)) continue;
-        switch (event.level) {
-            .error_level => remaining_errors += 1,
-            .warning => remaining_warnings += 1,
-        }
-    }
-    return exitCode(remaining_errors, remaining_warnings, options.strict);
+    return exitCode(
+        summary.error_count,
+        summary.warning_count - summary.format_warning_count,
+        options.strict,
+    );
 }
 
 fn isFixedByFormatRewrite(kind: Kind) bool {
@@ -386,25 +392,50 @@ pub fn fixRejection(summary: *const Summary, options: Options) ?Kind {
             else => {},
         }
     }
+    if (summary.truncated_fix_rejection) |kind| {
+        if (kind != .invalid_character or !options.fix_format_only) return kind;
+    }
     return null;
 }
 
 fn appendEvent(allocator: std.mem.Allocator, summary: *Summary, event: ValidateEvent) !void {
-    if (summary.events.items.len >= max_validate_events) {
-        summary.truncated = true;
-        return;
-    }
-    try summary.events.append(allocator, event);
     switch (event.level) {
         .error_level => summary.error_count += 1,
         .warning => summary.warning_count += 1,
+    }
+    summary.kind_counts[@intFromEnum(event.kind)] += 1;
+    if (isFixedByFormatRewrite(event.kind)) summary.format_warning_count += 1;
+
+    if (summary.events.items.len >= MAX_VALIDATE_EVENTS) {
+        summary.truncated = true;
+        noteTruncatedFixRejection(summary, event.kind);
+        return;
+    }
+    try summary.events.append(allocator, event);
+}
+
+fn noteTruncatedFixRejection(summary: *Summary, kind: Kind) void {
+    switch (kind) {
+        .invalid_character => {
+            if (summary.truncated_fix_rejection == null) {
+                summary.truncated_fix_rejection = .invalid_character;
+            }
+        },
+        .no_sequences, .duplicate_name, .null_byte => {
+            if (summary.truncated_fix_rejection == null or
+                summary.truncated_fix_rejection == .invalid_character)
+            {
+                summary.truncated_fix_rejection = kind;
+            }
+        },
+        else => {},
     }
 }
 
 fn startRecord(
     allocator: std.mem.Allocator,
     summary: *Summary,
-    seen_names: *std.StringHashMap(usize),
+    seen_names: *std.StringHashMapUnmanaged(usize),
     state: *RecordState,
     line: []const u8,
     line_number: usize,
@@ -419,7 +450,7 @@ fn startRecord(
     while (name_end < line.len and line[name_end] != ' ' and line[name_end] != '\t') : (name_end += 1) {}
     state.name = line[1..name_end];
 
-    const gop = try seen_names.getOrPut(state.name);
+    const gop = try seen_names.getOrPut(allocator, state.name);
     if (gop.found_existing) {
         try appendEvent(allocator, summary, .{
             .level = .error_level,
@@ -464,6 +495,23 @@ fn startRecord(
 
 fn finalizeRecord(allocator: std.mem.Allocator, summary: *Summary, state: *RecordState) !void {
     if (!state.active) return;
+
+    if (!state.width_warning_emitted) {
+        if (state.expected_width) |expected| {
+            if (state.pending_width) |final_width| {
+                if (final_width > expected) {
+                    try appendEvent(allocator, summary, .{
+                        .level = .warning,
+                        .kind = .inconsistent_line_widths,
+                        .line = state.pending_line,
+                        .name = state.name,
+                        .expected_width = expected,
+                        .actual_width = final_width,
+                    });
+                }
+            }
+        }
+    }
 
     if (state.bases == 0) {
         try appendEvent(allocator, summary, .{
@@ -583,7 +631,7 @@ fn updateWidth(allocator: std.mem.Allocator, state: *RecordState, width: u32) !v
 
 fn modalWidth(state: *const RecordState) u32 {
     var best_width: u32 = DEFAULT_FIX_WIDTH;
-    var best_count: u32 = 0;
+    var best_count: usize = 0;
     var best_order: usize = std.math.maxInt(usize);
     for (state.widths.items) |entry| {
         if (entry.count > best_count or (entry.count == best_count and entry.first_order < best_order)) {
@@ -625,11 +673,9 @@ fn appendInvalidCharacterEvents(
     }
 }
 
-fn buildAlphabet(chars: ?[]const u8) [256]bool {
+fn buildAlphabet(chars: []const u8) [256]bool {
     var table = [_]bool{false} ** 256;
-    if (chars) |bytes| {
-        for (bytes) |byte| table[byte] = true;
-    }
+    for (chars) |byte| table[byte] = true;
     return table;
 }
 
@@ -720,23 +766,41 @@ fn ensureFixAllowed(summary: *const Summary, options: Options) void {
 
 /// Rewrite format-level issues to normalized LF FASTA bytes. Caller must run validateData first.
 /// Allocates the full result for tests and library callers; CLI `--fix` streams via `writeFixed`.
+/// Allocator-backed writer failures are reported as `error.OutOfMemory`.
 pub fn fixData(allocator: std.mem.Allocator, data: []const u8, record_widths: []const u32) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
-    try writeFixedContent(&aw.writer, data, record_widths);
+    writeFixedContent(&aw.writer, data, record_widths) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+    };
     return try aw.toOwnedSlice();
 }
 
 fn writeFixed(io: std.Io, data: []const u8, record_widths: []const u32, output_path: []const u8) !void {
     const cwd = std.Io.Dir.cwd();
-    const out_file = try cwd.createFile(io, output_path, .{ .truncate = true });
-    errdefer cwd.deleteFile(io, output_path) catch {};
-    defer out_file.close(io);
+    var atomic_file = try cwd.createFileAtomic(io, output_path, .{ .replace = true });
+    defer atomic_file.deinit(io);
 
     var out_buf: [65536]u8 = undefined;
-    var file_fw = out_file.writer(io, &out_buf);
+    var file_fw = atomic_file.file.writer(io, &out_buf);
     try writeFixedContent(&file_fw.interface, data, record_widths);
     try file_fw.flush();
+    try atomic_file.replace(io);
+}
+
+fn outputResolvesToInput(io: std.Io, input_file: std.Io.File, output_path: []const u8) bool {
+    const output_file = std.Io.Dir.cwd().openFile(io, output_path, .{}) catch return false;
+    defer output_file.close(io);
+
+    var input_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const input_path_len = input_file.realPath(io, &input_path_buf) catch return false;
+    var output_path_buf: [std.Io.Dir.max_path_bytes]u8 = undefined;
+    const output_path_len = output_file.realPath(io, &output_path_buf) catch return false;
+    return std.mem.eql(
+        u8,
+        input_path_buf[0..input_path_len],
+        output_path_buf[0..output_path_len],
+    );
 }
 
 fn writeFixedContent(writer: *std.Io.Writer, data: []const u8, record_widths: []const u32) !void {
@@ -960,11 +1024,7 @@ fn allKinds() []const Kind {
 }
 
 fn countKind(summary: *const Summary, kind: Kind) usize {
-    var count: usize = 0;
-    for (summary.events.items) |event| {
-        if (event.kind == kind) count += 1;
-    }
-    return count;
+    return summary.kind_counts[@intFromEnum(kind)];
 }
 
 fn firstKind(summary: *const Summary, kind: Kind) ?ValidateEvent {

--- a/src/validator.zig
+++ b/src/validator.zig
@@ -27,18 +27,24 @@ comptime {
     }
 }
 
+/// Selects the stable text, JSON-lines, or aggregate JSON report.
 pub const OutputMode = enum {
     text,
     json_lines,
     json_summary,
 };
 
+/// Optional header convention checked in addition to ordinary FASTA validation.
 pub const Schema = enum {
     none,
     uniprot,
     refseq,
 };
 
+/// Controls validation, reporting, and format-only rewriting.
+///
+/// `output_path` and `custom_alphabet` are borrowed for the call. Direct CLI-equivalent
+/// callers must pair `fix_format_only` and `output_path` with `fix`.
 pub const Options = struct {
     strict: bool = false,
     output_mode: OutputMode = .text,
@@ -50,6 +56,7 @@ pub const Options = struct {
     max_header_len: usize = DEFAULT_MAX_HEADER_LEN,
 };
 
+/// Severity used for report events and exit-status accounting.
 pub const Level = enum {
     error_level,
     warning,
@@ -69,6 +76,7 @@ pub const Level = enum {
     }
 };
 
+/// Stable validation issue families used by text and JSON reports.
 pub const Kind = enum {
     no_sequences,
     duplicate_name,
@@ -103,6 +111,8 @@ pub const Kind = enum {
 
 const KIND_COUNT = @typeInfo(Kind).@"enum".fields.len;
 
+/// One retained issue. `name` borrows the validated input; other optional fields apply only
+/// to the issue kinds that expose them in the report schema.
 pub const ValidateEvent = struct {
     level: Level,
     kind: Kind,
@@ -115,6 +125,8 @@ pub const ValidateEvent = struct {
     limit: usize = 0,
 };
 
+/// Owns retained events and rewrite widths while borrowing event names from the input.
+/// Counts remain complete when `truncated` is true, although `events` does not.
 pub const Summary = struct {
     events: std.ArrayList(ValidateEvent),
     record_widths: std.ArrayList(u32),
@@ -132,6 +144,7 @@ pub const Summary = struct {
     /// Fix blocker found after event retention reached its cap.
     truncated_fix_rejection: ?Kind = null,
 
+    /// Releases owned storage with the allocator passed to `validateData`.
     pub fn deinit(self: *Summary, allocator: std.mem.Allocator) void {
         self.events.deinit(allocator);
         self.record_widths.deinit(allocator);
@@ -148,7 +161,7 @@ const RecordState = struct {
     active: bool = false,
     name: []const u8 = "",
     header_line: usize = 0,
-    bases: u64 = 0,
+    has_bases: bool = false,
     expected_width: ?u32 = null,
     pending_width: ?u32 = null,
     pending_line: usize = 0,
@@ -160,7 +173,7 @@ const RecordState = struct {
         self.active = false;
         self.name = "";
         self.header_line = 0;
-        self.bases = 0;
+        self.has_bases = false;
         self.expected_width = null;
         self.pending_width = null;
         self.pending_line = 0;
@@ -170,9 +183,9 @@ const RecordState = struct {
     }
 };
 
+/// Validates one FASTA, optionally atomically rewrites it, reports, and exits the process.
+/// Direct callers must supply CLI-valid option combinations.
 pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
-    // Mapping ownership matches LoadedIndex: one MemoryMap (or empty), destroyed here.
-    // Validation does not load an index; GET/stats use LoadedIndex.deinit() instead.
     const file = std.Io.Dir.cwd().openFile(io, fasta_path, .{}) catch |err| switch (err) {
         error.FileNotFound => printErrorAndExit("error: file not found: {s}\n", .{fasta_path}),
         error.AccessDenied => printErrorAndExit("error: access denied: {s}\n", .{fasta_path}),
@@ -207,6 +220,10 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
 
     var summary = validateData(allocator, data, options) catch |err| switch (err) {
         error.OutOfMemory => printErrorAndExit("error: out of memory\n", .{}),
+        error.SequenceLineTooLong => printErrorAndExit(
+            "error: sequence line exceeds the index format limit: {s}\n",
+            .{fasta_path},
+        ),
     };
     defer summary.deinit(allocator);
 
@@ -227,7 +244,7 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
 
     var out_buf: [65536]u8 = undefined;
     var stdout_fw = std.Io.File.Writer.initStreaming(.stdout(), io, &out_buf);
-    writeSummary(allocator, &stdout_fw.interface, &summary, options) catch {
+    writeSummary(&stdout_fw.interface, &summary, options) catch {
         stdout_fw.flush() catch {};
         printErrorAndExit("error: write failed\n", .{});
     };
@@ -236,9 +253,7 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
     };
 
     if (summary.truncated) {
-        // Event retention is capped for reporting. Scanning (and --fix rewrite via
-        // record_widths) still covers the whole file. Without --fix, stop so callers
-        // know the report is incomplete. With --fix, the rewrite already finished.
+        // An incomplete report is fatal unless the requested rewrite already completed.
         if (!options.fix) {
             printErrorAndExit(
                 "error: validate stopped after {d} events; fix reported issues and re-run\n",
@@ -254,6 +269,9 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
     std.process.exit(exitCodeForOptions(&summary, options));
 }
 
+/// Scans all input bytes and returns an owning summary whose event names borrow `data`.
+/// Retained events are capped, but counts, fix blockers, and rewrite widths remain complete.
+/// A sequence line wider than the index format can represent returns `error.SequenceLineTooLong`.
 pub fn validateData(allocator: std.mem.Allocator, data: []const u8, options: Options) !Summary {
     var summary = Summary{
         .events = .empty,
@@ -355,12 +373,14 @@ pub fn validateData(allocator: std.mem.Allocator, data: []const u8, options: Opt
     return summary;
 }
 
+/// Returns the validate status for complete severity counts and strictness.
 pub fn exitCode(error_count: usize, warning_count: usize, strict: bool) u8 {
     if (error_count > 0) return 1;
     if (warning_count > 0) return if (strict) 1 else 2;
     return 0;
 }
 
+/// Returns validate status after excluding warnings repaired by a requested format rewrite.
 pub fn exitCodeForOptions(summary: *const Summary, options: Options) u8 {
     if (!options.fix) return exitCode(summary.error_count, summary.warning_count, options.strict);
 
@@ -372,7 +392,6 @@ pub fn exitCodeForOptions(summary: *const Summary, options: Options) u8 {
 }
 
 fn isFixedByFormatRewrite(kind: Kind) bool {
-    // --fix rewrites only these kinds. Everything else is left unchanged or blocks fix.
     return switch (kind) {
         .utf8_bom,
         .inconsistent_line_widths,
@@ -384,6 +403,7 @@ fn isFixedByFormatRewrite(kind: Kind) bool {
     };
 }
 
+/// Returns the first issue that prevents the requested rewrite, including issues past the cap.
 pub fn fixRejection(summary: *const Summary, options: Options) ?Kind {
     for (summary.events.items) |event| {
         switch (event.kind) {
@@ -513,7 +533,7 @@ fn finalizeRecord(allocator: std.mem.Allocator, summary: *Summary, state: *Recor
         }
     }
 
-    if (state.bases == 0) {
+    if (!state.has_bases) {
         try appendEvent(allocator, summary, .{
             .level = .warning,
             .kind = .empty_sequence,
@@ -561,8 +581,9 @@ fn scanSequenceLine(
         });
     }
 
-    const width: u32 = @intCast(trimmed.len);
+    const width = std.math.cast(u32, trimmed.len) orelse return error.SequenceLineTooLong;
     if (width > 0) {
+        state.has_bases = true;
         try updateWidth(allocator, state, width);
         if (state.pending_width) |pending_width| {
             const expected = state.expected_width orelse pending_width;
@@ -583,7 +604,6 @@ fn scanSequenceLine(
         state.pending_line = line_number;
     }
 
-    state.bases += width;
     for (trimmed) |byte| {
         byte_counts[byte] += 1;
         if (first_byte_line[byte] == 0) first_byte_line[byte] = line_number;
@@ -655,7 +675,7 @@ fn appendInvalidCharacterEvents(
         buildAlphabet(custom)
     else switch (sequence_type) {
         .nucleotide => buildAlphabet("ACGTUNRYWSMKHBVDacgtunrywsmkhbvd"),
-        .protein => buildAlphabet("ACDEFGHIKLMNPQRSTVWYUOX*-acdefghiklmnpqrstvwyuox"),
+        .protein => buildAlphabet("ACDEFGHIKLMNPQRSTVWYBZJXUO*-acdefghiklmnpqrstvwybzjxuo"),
     };
 
     for (byte_counts, 0..) |count, i| {
@@ -853,16 +873,14 @@ fn writeFixedContent(writer: *std.Io.Writer, data: []const u8, record_widths: []
 
     if (in_record and line_pos > 0) {
         try writer.writeByte('\n');
-    } else if (in_record and (data.len == 0 or data[data.len - 1] != '\n')) {
-        try writer.writeByte('\n');
     }
 }
 
-fn writeSummary(allocator: std.mem.Allocator, writer: anytype, summary: *const Summary, options: Options) !void {
+fn writeSummary(writer: anytype, summary: *const Summary, options: Options) !void {
     switch (options.output_mode) {
         .text => try writeText(writer, summary),
-        .json_lines => try writeJsonLines(allocator, writer, summary),
-        .json_summary => try writeJsonSummary(allocator, writer, summary),
+        .json_lines => try writeJsonLines(writer, summary),
+        .json_summary => try writeJsonSummary(writer, summary),
     }
 }
 
@@ -874,36 +892,64 @@ fn writeText(writer: anytype, summary: *const Summary) !void {
 
     for (summary.events.items) |event| {
         try writer.print("{s}: line {d}: ", .{ event.level.label(), event.line });
-        try writeHumanMessage(writer, event);
+        try writeMessage(writer, event, false);
         try writer.writeByte('\n');
     }
 }
 
-fn writeHumanMessage(writer: anytype, event: ValidateEvent) !void {
+fn writeMessage(writer: anytype, event: ValidateEvent, comptime escape_names: bool) !void {
     switch (event.kind) {
         .no_sequences => try writer.writeAll("no sequences found"),
-        .duplicate_name => try writer.print("duplicate name '{s}' (first seen line {d})", .{ event.name, event.first_line }),
+        .duplicate_name => {
+            try writer.writeAll("duplicate name '");
+            try writeName(writer, event.name, escape_names);
+            try writer.print("' (first seen line {d})", .{event.first_line});
+        },
         .invalid_character => try writer.print("invalid sequence character 0x{x:0>2}", .{event.byte}),
         .null_byte => try writer.writeAll("null byte found"),
         .utf8_bom => try writer.writeAll("UTF-8 BOM at start of file"),
-        .inconsistent_line_widths => try writer.print("inconsistent line width in '{s}' (expected {d}, found {d})", .{ event.name, event.expected_width, event.actual_width }),
-        .trailing_whitespace => try writer.print("trailing whitespace on sequence line in '{s}'", .{event.name}),
-        .empty_sequence => try writer.print("empty sequence '{s}'", .{event.name}),
+        .inconsistent_line_widths => {
+            try writer.writeAll("inconsistent line width in '");
+            try writeName(writer, event.name, escape_names);
+            try writer.print("' (expected {d}, found {d})", .{ event.expected_width, event.actual_width });
+        },
+        .trailing_whitespace => {
+            try writer.writeAll("trailing whitespace on sequence line in '");
+            try writeName(writer, event.name, escape_names);
+            try writer.writeByte('\'');
+        },
+        .empty_sequence => {
+            try writer.writeAll("empty sequence '");
+            try writeName(writer, event.name, escape_names);
+            try writer.writeByte('\'');
+        },
         .missing_terminal_newline => try writer.writeAll("missing terminal newline"),
         .mixed_line_endings => try writer.writeAll("mixed CRLF and LF line endings"),
         .long_header => try writer.print("header exceeds {d} bytes", .{event.limit}),
-        .schema_violation => try writer.print("header for '{s}' does not match schema", .{event.name}),
+        .schema_violation => {
+            try writer.writeAll("header for '");
+            try writeName(writer, event.name, escape_names);
+            try writer.writeAll("' does not match schema");
+        },
     }
 }
 
-fn writeJsonLines(allocator: std.mem.Allocator, writer: anytype, summary: *const Summary) !void {
+fn writeName(writer: anytype, name: []const u8, comptime escape: bool) !void {
+    if (escape) {
+        try writeJsonStringBytes(writer, name);
+    } else {
+        try writer.writeAll(name);
+    }
+}
+
+fn writeJsonLines(writer: anytype, summary: *const Summary) !void {
     for (summary.events.items) |event| {
-        try writeJsonEventObject(allocator, writer, event);
+        try writeJsonEventObject(writer, event);
         try writer.writeByte('\n');
     }
 }
 
-fn writeJsonSummary(allocator: std.mem.Allocator, writer: anytype, summary: *const Summary) !void {
+fn writeJsonSummary(writer: anytype, summary: *const Summary) !void {
     const type_str: []const u8 = switch (summary.sequence_type) {
         .nucleotide => "nucleotide",
         .protein => "protein",
@@ -927,19 +973,19 @@ fn writeJsonSummary(allocator: std.mem.Allocator, writer: anytype, summary: *con
         if (firstKind(summary, kind)) |event| {
             if (wrote_example) try writer.writeByte(',');
             try writer.print("\"{s}\":", .{kind.text()});
-            try writeJsonEventObject(allocator, writer, event);
+            try writeJsonEventObject(writer, event);
             wrote_example = true;
         }
     }
     try writer.writeAll("}}\n");
 }
 
-fn writeJsonEventObject(allocator: std.mem.Allocator, writer: anytype, event: ValidateEvent) !void {
+fn writeJsonEventObject(writer: anytype, event: ValidateEvent) !void {
     try writer.print(
         "{{\"schema_version\":\"v1\",\"level\":\"{s}\",\"line\":{d},\"kind\":\"{s}\",\"message\":\"",
         .{ event.level.text(), event.line, event.kind.text() },
     );
-    try writeJsonMessage(allocator, writer, event);
+    try writeMessage(writer, event, true);
     try writer.writeByte('"');
     if (event.name.len > 0) {
         try writer.writeAll(",\"name\":\"");
@@ -951,15 +997,7 @@ fn writeJsonEventObject(allocator: std.mem.Allocator, writer: anytype, event: Va
     try writer.writeByte('}');
 }
 
-fn writeJsonMessage(allocator: std.mem.Allocator, writer: anytype, event: ValidateEvent) !void {
-    var aw: std.Io.Writer.Allocating = .init(allocator);
-    defer aw.deinit();
-    try writeHumanMessage(&aw.writer, event);
-    try writeJsonStringBytes(writer, aw.written());
-}
-
-/// Write `text` inside a JSON string. ASCII controls and quotes are escaped.
-/// Invalid UTF-8 bytes become `\u00XX` so the overall document stays valid UTF-8 JSON.
+// Invalid UTF-8 bytes become `\u00XX` so the enclosing JSON remains valid UTF-8.
 fn writeJsonStringBytes(writer: anytype, text: []const u8) !void {
     var i: usize = 0;
     while (i < text.len) {
@@ -998,11 +1036,14 @@ fn writeJsonStringBytes(writer: anytype, text: []const u8) !void {
     }
 }
 
-/// Render one JSON event object (no trailing newline). For tests and tooling.
+/// Returns one caller-owned JSON event object without a trailing newline.
+/// Allocator-backed writer failures are reported as `error.OutOfMemory`.
 pub fn renderJsonEvent(allocator: std.mem.Allocator, event: ValidateEvent) ![]u8 {
     var aw: std.Io.Writer.Allocating = .init(allocator);
     errdefer aw.deinit();
-    try writeJsonEventObject(allocator, &aw.writer, event);
+    writeJsonEventObject(&aw.writer, event) catch |err| switch (err) {
+        error.WriteFailed => return error.OutOfMemory,
+    };
     return try aw.toOwnedSlice();
 }
 

--- a/src/validator.zig
+++ b/src/validator.zig
@@ -117,7 +117,7 @@ pub const Summary = struct {
     events: std.ArrayList(ValidateEvent),
     record_widths: std.ArrayList(u32),
     sequence_type: stats.SequenceType = .nucleotide,
-    /// Bases fed into `detectType` (capped at `stats.validate_type_sample_bases`).
+    /// Bases fed into `detectType` (capped at `stats.VALIDATE_TYPE_SAMPLE_BASES`).
     type_bases_sampled: u64 = 0,
     sequence_count: usize = 0,
     header_count: usize = 0,
@@ -165,8 +165,8 @@ const RecordState = struct {
 };
 
 pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
-    // Mapping ownership matches LoadedIndex: one FileView (or empty), destroyed here.
-    // Validation does not load an index; GET/stats use LoadedIndex.deinit(io) instead.
+    // Mapping ownership matches LoadedIndex: one MemoryMap (or empty), destroyed here.
+    // Validation does not load an index; GET/stats use LoadedIndex.deinit() instead.
     const file = std.Io.Dir.cwd().openFile(io, fasta_path, .{}) catch |err| switch (err) {
         error.FileNotFound => printErrorAndExit("error: file not found: {s}\n", .{fasta_path}),
         error.AccessDenied => printErrorAndExit("error: access denied: {s}\n", .{fasta_path}),
@@ -178,21 +178,19 @@ pub fn runValidate(io: std.Io, fasta_path: []const u8, options: Options) void {
         printErrorAndExit("error: failed to stat file: {s}\n", .{fasta_path});
     };
 
-    var fasta_view: ?platform.FileView = null;
-    defer if (fasta_view) |*view| view.destroy(io);
+    var fasta_map: ?std.Io.File.MemoryMap = null;
+    defer if (fasta_map) |*map| map.destroy(io);
 
     const data: []const u8 = if (stat.size == 0)
         &[_]u8{}
     else blk: {
-        fasta_view = platform.FileView.mapFile(io, file, @intCast(stat.size)) catch {
+        fasta_map = platform.mapFileReadOnly(io, file, @intCast(stat.size)) catch {
             printErrorAndExit("error: failed to mmap file: {s}\n", .{fasta_path});
         };
-        break :blk fasta_view.?.bytes();
+        break :blk fasta_map.?.memory;
     };
 
-    if (data.len > 0) {
-        platform.advise(data, .sequential);
-    }
+    if (fasta_map) |*map| platform.adviseSequential(map.memory);
 
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
@@ -542,7 +540,7 @@ fn scanSequenceLine(
         byte_counts[byte] += 1;
         if (first_byte_line[byte] == 0) first_byte_line[byte] = line_number;
 
-        if (type_total.* < stats.validate_type_sample_bases) {
+        if (type_total.* < stats.VALIDATE_TYPE_SAMPLE_BASES) {
             type_counts[byte] += 1;
             type_total.* += 1;
         }
@@ -852,7 +850,7 @@ fn writeJsonSummary(allocator: std.mem.Allocator, writer: anytype, summary: *con
             if (summary.truncated) "true" else "false",
             type_str,
             summary.type_bases_sampled,
-            stats.validate_type_sample_bases,
+            stats.VALIDATE_TYPE_SAMPLE_BASES,
         },
     );
     for (allKinds(), 0..) |kind, i| {

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -5,6 +5,7 @@
 const std = @import("std");
 const main = @import("main");
 const utility = @import("utility.zig");
+const parseRegion = main.getter.parseRegion;
 const resolveRegion = main.getter.resolveRegion;
 const io = std.testing.io;
 
@@ -16,6 +17,62 @@ const uniqueArtifactPath = utility.uniqueArtifactPath;
 const writeFastaArtifact = utility.writeFastaArtifact;
 const writeZfi = utility.writeZfi;
 const captureExtractRegion = utility.captureExtractRegion;
+
+test "[unit] - [region parser]: distinguishes literal names and rightmost coordinate suffixes" {
+    const Case = struct {
+        input: []const u8,
+        name: []const u8,
+        start: u64 = 1,
+        end: ?u64 = null,
+        is_full: bool = true,
+    };
+    const max = std.math.maxInt(u64);
+    const cases = [_]Case{
+        .{ .input = "seq1", .name = "seq1" },
+        .{ .input = "seq1:3-8", .name = "seq1", .start = 3, .end = 8, .is_full = false },
+        .{ .input = "seq1:3-", .name = "seq1", .start = 3, .is_full = false },
+        .{ .input = ":1-2", .name = "", .end = 2, .is_full = false },
+        .{
+            .input = "chromosome:GRCh38:1:1:248956422:1",
+            .name = "chromosome:GRCh38:1:1:248956422:1",
+        },
+        .{
+            .input = "chromosome:GRCh38:1:1:248956422:1:100-200",
+            .name = "chromosome:GRCh38:1:1:248956422:1",
+            .start = 100,
+            .end = 200,
+            .is_full = false,
+        },
+        .{ .input = "name:1-2:bad", .name = "name:1-2:bad" },
+        .{ .input = "name:18446744073709551616-1", .name = "name:18446744073709551616-1" },
+        .{ .input = "name:1-18446744073709551616", .name = "name:1-18446744073709551616" },
+        .{
+            .input = "name:18446744073709551615-18446744073709551615",
+            .name = "name",
+            .start = max,
+            .end = max,
+            .is_full = false,
+        },
+    };
+
+    for (cases) |case| {
+        const region = parseRegion(case.input);
+        try std.testing.expectEqualStrings(case.name, region.name);
+        try std.testing.expectEqual(case.start, region.start);
+        try std.testing.expectEqual(case.end, region.end);
+        try std.testing.expectEqual(case.is_full, region.is_full);
+    }
+}
+
+test "[unit] - [get orientation]: composes independent reverse and complement operations" {
+    const reverse_complement = main.getter.Orientation.reverseComplement();
+    const reverse = main.getter.Orientation.reverseOnly();
+    const complement = main.getter.Orientation.complementOnly();
+
+    try std.testing.expect(reverse_complement.compose(reverse_complement).isIdentity());
+    try std.testing.expectEqual(complement, reverse_complement.compose(reverse));
+    try std.testing.expectEqual(reverse, reverse_complement.compose(complement));
+}
 
 test "[integration] - [region resolution]: preserves indexed coordinate geometry" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -13,6 +13,9 @@ const expectCliFailure = utility.expectCliFailure;
 const expectCliSuccess = utility.expectCliSuccess;
 const expectUnknownOptionRejected = utility.expectUnknownOptionRejected;
 const uniqueArtifactPath = utility.uniqueArtifactPath;
+const writeFastaArtifact = utility.writeFastaArtifact;
+const writeZfi = utility.writeZfi;
+const captureExtractRegion = utility.captureExtractRegion;
 
 test "[integration] - [region resolution]: preserves indexed coordinate geometry" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
@@ -71,42 +74,6 @@ test "[integration] - [region resolution]: accepts a 200-byte identifier" {
 
 // --- Index-backed get fixtures ---
 
-fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]const u8 {
-    const path = try uniqueArtifactPath(allocator, stem, "fa");
-    errdefer allocator.free(path);
-    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
-    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
-    defer file.close(io);
-    try std.Io.File.writeStreamingAll(file, io, data);
-    return path;
-}
-
-fn writeZfi(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const u8, enable_dedup: bool) !void {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var index = try main.indexer.scanZfiData(data, enable_dedup, arena.allocator());
-    defer index.deinit(arena.allocator());
-
-    const fasta_file = try std.Io.Dir.cwd().openFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    const mtime_ns = main.index_format.timestampToNs((try fasta_file.stat(io)).mtime);
-
-    var zfi_path_buf: [4096]u8 = undefined;
-    const zfi_path = try std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{fasta_path});
-    try main.indexer.writeZfiIndexFile(io, zfi_path, &index, data.len, mtime_ns);
-}
-
-fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(allocator, io, fasta_path);
-    defer idx.deinit();
-
-    var out = std.Io.Writer.Allocating.init(allocator);
-    errdefer out.deinit();
-    main.getter.extractRegion(&idx, region, &out.writer);
-    return out.toOwnedSlice();
-}
-
 test "[property] - [get extraction]: zfi and fai match across uniform FASTA lines" {
     const data = @embedFile("data/simple.fasta");
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -114,9 +81,9 @@ test "[property] - [get extraction]: zfi and fai match across uniform FASTA line
     const allocator = arena.allocator();
 
     const path = try writeFastaArtifact(allocator, "get-sam", data);
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{path});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{path});
-    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
@@ -172,8 +139,8 @@ test "[integration] - [get extraction]: extracts across non-uniform FASTA lines"
     const allocator = arena.allocator();
 
     const path = try writeFastaArtifact(allocator, "get-messy", data);
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{path});
     defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     try writeZfi(allocator, path, data, true);
@@ -196,9 +163,9 @@ test "[cli] - [get]: selects the first empty identifier through zfi and fai" {
     const allocator = arena.allocator();
 
     const fasta_path = try writeFastaArtifact(allocator, "get-empty-name", data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
@@ -328,14 +295,14 @@ test "[cli] - [get names]: accepts the index name-length boundary in both format
     try expected.appendSlice(allocator, "\nA\n");
 
     const zfi_fasta = try writeFastaArtifact(allocator, "names-max-zfi", fasta.items);
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{zfi_fasta});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_fasta) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{zfi_fasta});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     try writeZfi(allocator, zfi_fasta, fasta.items, true);
 
     const fai_fasta = try writeFastaArtifact(allocator, "names-max-fai", fasta.items);
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fai_fasta});
     defer std.Io.Dir.cwd().deleteFile(io, fai_fasta) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fai_fasta});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
@@ -408,9 +375,9 @@ test "[cli] - [get index selection]: invalid zfi blocks a valid fai" {
     const allocator = arena.allocator();
 
     const fasta = try writeFastaArtifact(allocator, "invalid-zfi-cli", ">seq\nACGT\n");
+    defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
@@ -490,8 +457,8 @@ test "[cli] - [get]: rejects invalid requests, missing names, and transform conf
     const allocator = arena.allocator();
 
     const fasta = try writeFastaArtifact(allocator, "get-cli-errors", @embedFile("data/simple.fasta"));
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
     defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     {

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -11,99 +11,51 @@ const io = std.testing.io;
 
 const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
 
-// ============================================================================
-// Region parsing tests
-// ============================================================================
+// --- Region parsing tests ---
 
-test "parseRegion - simple name" {
-    const r = parseRegion("chr1");
-    try std.testing.expectEqualStrings("chr1", r.name);
-    try std.testing.expect(r.is_full);
+test "parseRegion recognizes names and coordinate suffixes" {
+    const Case = struct {
+        input: []const u8,
+        name: []const u8,
+        start: u64 = 1,
+        end: ?u64 = null,
+        is_full: bool = true,
+    };
+    const cases = [_]Case{
+        .{ .input = "chr1", .name = "chr1" },
+        .{ .input = "", .name = "" },
+        .{ .input = "chr1:100-200", .name = "chr1", .start = 100, .end = 200, .is_full = false },
+        .{ .input = "chr1:100-", .name = "chr1", .start = 100, .is_full = false },
+        .{
+            .input = "chromosome:GRCh38:1:1:248956422:1:100-200",
+            .name = "chromosome:GRCh38:1:1:248956422:1",
+            .start = 100,
+            .end = 200,
+            .is_full = false,
+        },
+        .{
+            .input = "chromosome:GRCh38:1:1:248956422:1",
+            .name = "chromosome:GRCh38:1:1:248956422:1",
+        },
+        .{ .input = "sp|P12345|PROT_NAME:1-50", .name = "sp|P12345|PROT_NAME", .end = 50, .is_full = false },
+        .{ .input = "chr1:1-1", .name = "chr1", .end = 1, .is_full = false },
+        .{ .input = "chr1:1000000-2000000", .name = "chr1", .start = 1_000_000, .end = 2_000_000, .is_full = false },
+        .{ .input = "KI270394.1:1-100", .name = "KI270394.1", .end = 100, .is_full = false },
+        .{ .input = "1:1", .name = "1:1" },
+        .{ .input = "chr1.1.2.3", .name = "chr1.1.2.3" },
+    };
+
+    for (cases) |case| {
+        const region = parseRegion(case.input);
+
+        try std.testing.expectEqualStrings(case.name, region.name);
+        try std.testing.expectEqual(case.start, region.start);
+        try std.testing.expectEqual(case.end, region.end);
+        try std.testing.expectEqual(case.is_full, region.is_full);
+    }
 }
 
-test "parseRegion - empty identifier" {
-    const r = parseRegion("");
-    try std.testing.expectEqualStrings("", r.name);
-    try std.testing.expect(r.is_full);
-}
-
-test "parseRegion - name with range" {
-    const r = parseRegion("chr1:100-200");
-    try std.testing.expectEqualStrings("chr1", r.name);
-    try std.testing.expectEqual(@as(u64, 100), r.start);
-    try std.testing.expectEqual(@as(?u64, 200), r.end);
-    try std.testing.expect(!r.is_full);
-}
-
-test "parseRegion - name with open end" {
-    const r = parseRegion("chr1:100-");
-    try std.testing.expectEqualStrings("chr1", r.name);
-    try std.testing.expectEqual(@as(u64, 100), r.start);
-    try std.testing.expectEqual(@as(?u64, null), r.end);
-    try std.testing.expect(!r.is_full);
-}
-
-test "parseRegion - Ensembl colon name with range" {
-    const r = parseRegion("chromosome:GRCh38:1:1:248956422:1:100-200");
-    try std.testing.expectEqualStrings("chromosome:GRCh38:1:1:248956422:1", r.name);
-    try std.testing.expectEqual(@as(u64, 100), r.start);
-    try std.testing.expectEqual(@as(?u64, 200), r.end);
-    try std.testing.expect(!r.is_full);
-}
-
-test "parseRegion - Ensembl colon name without range" {
-    const r = parseRegion("chromosome:GRCh38:1:1:248956422:1");
-    try std.testing.expectEqualStrings("chromosome:GRCh38:1:1:248956422:1", r.name);
-    try std.testing.expect(r.is_full);
-}
-
-test "parseRegion - pipe-delimited protein name" {
-    const r = parseRegion("sp|P12345|PROT_NAME:1-50");
-    try std.testing.expectEqualStrings("sp|P12345|PROT_NAME", r.name);
-    try std.testing.expectEqual(@as(u64, 1), r.start);
-    try std.testing.expectEqual(@as(?u64, 50), r.end);
-}
-
-test "parseRegion - single base" {
-    const r = parseRegion("chr1:1-1");
-    try std.testing.expectEqualStrings("chr1", r.name);
-    try std.testing.expectEqual(@as(u64, 1), r.start);
-    try std.testing.expectEqual(@as(?u64, 1), r.end);
-    try std.testing.expect(!r.is_full);
-}
-
-test "parseRegion - large coordinates" {
-    const r = parseRegion("chr1:1000000-2000000");
-    try std.testing.expectEqualStrings("chr1", r.name);
-    try std.testing.expectEqual(@as(u64, 1_000_000), r.start);
-    try std.testing.expectEqual(@as(?u64, 2_000_000), r.end);
-}
-
-test "parseRegion - name with underscore and range" {
-    const r = parseRegion("KI270394.1:1-100");
-    try std.testing.expectEqualStrings("KI270394.1", r.name);
-    try std.testing.expectEqual(@as(u64, 1), r.start);
-    try std.testing.expectEqual(@as(?u64, 100), r.end);
-}
-
-test "parseRegion - name with colon but no valid range" {
-    // "1:1" looks like it could be parsed as name="1", start=1, end=null ...
-    // but there's no dash, so parseRangeSuffix returns null.
-    // The whole thing should be treated as a name.
-    const r = parseRegion("1:1");
-    try std.testing.expectEqualStrings("1:1", r.name);
-    try std.testing.expect(r.is_full);
-}
-
-test "parseRegion - name only with dots" {
-    const r = parseRegion("chr1.1.2.3");
-    try std.testing.expectEqualStrings("chr1.1.2.3", r.name);
-    try std.testing.expect(r.is_full);
-}
-
-// ============================================================================
-// Index loading tests
-// ============================================================================
+// --- Index loading tests ---
 
 test "loadIndex - .zfi file" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
@@ -131,15 +83,14 @@ test "loadIndex - .zfi file" {
     try std.testing.expectEqual(@as(?usize, null), idx.lookupName("nonexistent"));
 }
 
-// ============================================================================
-// Multi-region resolution tests
-// ============================================================================
+// --- Multi-region resolution tests ---
 
 test "resolveRegion - single region, full sequence" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
     defer idx.deinit();
 
     const r = resolveRegion(&idx, "seq1");
+
     try std.testing.expectEqualStrings("seq1", r.name);
     try std.testing.expect(r.is_full);
     try std.testing.expectEqual(@as(u64, 24), r.num_bases);
@@ -150,6 +101,7 @@ test "resolveRegion - single region, sub-range" {
     defer idx.deinit();
 
     const r = resolveRegion(&idx, "seq1:1-12");
+
     try std.testing.expectEqualStrings("seq1", r.name);
     try std.testing.expect(!r.is_full);
     try std.testing.expectEqual(@as(u64, 12), r.num_bases);
@@ -161,10 +113,9 @@ test "resolveRegion - end clamped silently" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
     defer idx.deinit();
 
-    // seq1 has 24 bases; request end=9999 should clamp to 24
     const r = resolveRegion(&idx, "seq1:1-9999");
+
     try std.testing.expectEqual(@as(u64, 24), r.num_bases);
-    // display_end should be the user-supplied value (before clamping)
     try std.testing.expectEqual(@as(u64, 9999), r.display_end);
 }
 
@@ -173,42 +124,21 @@ test "resolveRegion - first base resolves one symbol" {
     defer idx.deinit();
 
     const r = resolveRegion(&idx, "seq1:1-1");
+
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
 }
 
-test "resolveRegion - duplicate region preserves geometry" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r0 = resolveRegion(&idx, "seq1:1-5");
-    const r1 = resolveRegion(&idx, "seq1:1-5");
-
-    try std.testing.expectEqual(r0.seq_offset, r1.seq_offset);
-    try std.testing.expectEqual(r0.num_bases, r1.num_bases);
-}
-
-// ============================================================================
-// resolveRegion edge cases
-// ============================================================================
+// --- resolveRegion edge cases ---
 
 test "resolveRegion - open-ended region (NAME:START-) uses seq_len as end" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
     defer idx.deinit();
 
-    // seq1 has 24 bases; NAME:13- should return bases 13..24 = 12 bases
     const r = resolveRegion(&idx, "seq1:13-");
+
     try std.testing.expect(!r.is_full);
     try std.testing.expectEqual(@as(u64, 12), r.num_bases);
-    // display_end should be seq_len (24), not null
     try std.testing.expectEqual(@as(u64, 24), r.display_end);
-}
-
-test "resolveRegion - single-base region" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:1-1");
-    try std.testing.expectEqual(@as(u64, 1), r.num_bases);
 }
 
 test "resolveRegion - last-base region" {
@@ -216,16 +146,8 @@ test "resolveRegion - last-base region" {
     defer idx.deinit();
 
     const r = resolveRegion(&idx, "seq1:24-24");
+
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-}
-
-test "resolveRegion - cross-line region (starts line 1, ends line 2)" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    // seq1 wraps at 12 bases per line; region 10-15 crosses the line boundary
-    const r = resolveRegion(&idx, "seq1:10-15");
-    try std.testing.expectEqual(@as(u64, 6), r.num_bases);
 }
 
 test "resolveRegion - full and explicit ranges preserve geometry" {
@@ -234,19 +156,9 @@ test "resolveRegion - full and explicit ranges preserve geometry" {
 
     const r_full = resolveRegion(&idx, "seq1");
     const r_range = resolveRegion(&idx, "seq1:1-24");
+
     try std.testing.expectEqual(r_full.seq_offset, r_range.seq_offset);
     try std.testing.expectEqual(r_full.num_bases, r_range.num_bases);
-}
-
-test "resolveRegion - display_end before clamp, num_bases after clamp" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:1-9999");
-    // num_bases clamped to seq_len
-    try std.testing.expectEqual(@as(u64, 24), r.num_bases);
-    // display_end preserves user value
-    try std.testing.expectEqual(@as(u64, 9999), r.display_end);
 }
 
 test "resolveRegion - proteome pipe-delimited name" {
@@ -254,6 +166,7 @@ test "resolveRegion - proteome pipe-delimited name" {
     defer idx.deinit();
 
     const r = resolveRegion(&idx, "sp|P12345|PROT_HUMAN:1-10");
+
     try std.testing.expectEqualStrings("sp|P12345|PROT_HUMAN", r.name);
     try std.testing.expectEqual(@as(u64, 10), r.num_bases);
 }
@@ -262,52 +175,15 @@ test "resolveRegion - long header name (200-char sequence name)" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
     defer idx.deinit();
 
-    const long_name = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const long_name = "A" ** 200;
     const r = resolveRegion(&idx, long_name);
+
     try std.testing.expectEqualStrings(long_name, r.name);
     try std.testing.expect(r.is_full);
     try std.testing.expectEqual(@as(u64, 8), r.num_bases);
 }
 
-test "resolveRegion - lowercase record resolves" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
-    defer idx.deinit();
-
-    // 'lowercase' in edge_cases.fasta: acgtACGTacgt (12 bases)
-    const r = resolveRegion(&idx, "lowercase:1-1");
-    try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-}
-
-test "resolveRegion - ordering: seq2 has higher file offset than seq1" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r1 = resolveRegion(&idx, "seq1:1-1");
-    const r2 = resolveRegion(&idx, "seq2:1-1");
-    try std.testing.expect(r2.seq_offset > r1.seq_offset);
-}
-
-test "resolveRegion - file geometry is independent of request order" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r2 = resolveRegion(&idx, "seq2:1-1");
-    const r1 = resolveRegion(&idx, "seq1:1-1");
-    try std.testing.expect(r1.seq_offset < r2.seq_offset);
-}
-
-test "resolveRegion - nonstandard characters in sequence (stars/dashes)" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
-    defer idx.deinit();
-
-    // 'nonstandard' has ACG*-NACGT (10 chars)
-    const r = resolveRegion(&idx, "nonstandard:1-10");
-    try std.testing.expectEqual(@as(u64, 10), r.num_bases);
-}
-
-// ============================================================================
-// Index-backed get fixtures
-// ============================================================================
+// --- Index-backed get fixtures ---
 
 fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8, ext: []const u8) ![]u8 {
     try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
@@ -345,15 +221,16 @@ fn writeZfi(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const 
 }
 
 fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(std.testing.allocator, io, fasta_path);
+    var idx = try main.index_format.loadIndexChecked(allocator, io, fasta_path);
     defer idx.deinit();
 
     var out = std.Io.Writer.Allocating.init(allocator);
+    errdefer out.deinit();
     main.getter.extractRegion(&idx, region, &out.writer);
     return out.toOwnedSlice();
 }
 
-test "get on zfi output for simple.fasta seq1:1-10" {
+test "get extracts a region across uniform FASTA lines" {
     const data = @embedFile("data/simple.fasta");
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -366,13 +243,25 @@ test "get on zfi output for simple.fasta seq1:1-10" {
 
     try writeZfi(allocator, path, data, true);
 
-    const got = try captureExtractRegion(allocator, path, "seq1:1-10");
+    const got = try captureExtractRegion(allocator, path, "seq1:10-15");
     const expected =
-        \\>seq1:1-10
-        \\ACGTACGTAC
+        \\>seq1:10-15
+        \\CGTACG
         \\
     ;
     try std.testing.expectEqualStrings(expected, got);
+}
+
+test "get preserves lowercase and nonstandard sequence bytes" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const lowercase = try captureExtractRegion(allocator, "tests/data/edge_cases.fasta", "lowercase");
+    const nonstandard = try captureExtractRegion(allocator, "tests/data/edge_cases.fasta", "nonstandard");
+
+    try std.testing.expectEqualStrings(">lowercase\nacgtACGTacgt\n", lowercase);
+    try std.testing.expectEqualStrings(">nonstandard\nACG*-NACGT\n", nonstandard);
 }
 
 test "get on messy mixed_widths after indexing" {
@@ -431,7 +320,7 @@ test "CLI get selects the first empty identifier through zfi and fai" {
     try expectCliSuccess(allocator, &.{ ZFASTA_BIN, "get", fasta_path, "" }, ">\nAAAA\n");
 }
 
-/// Hard CLI failures: exact exit code, exact stderr, empty stdout (no partial success).
+// Hard CLI failures require exact exit code and stderr with no partial stdout.
 fn expectCliFailure(
     allocator: std.mem.Allocator,
     argv: []const []const u8,
@@ -478,7 +367,7 @@ fn expectCliSuccess(allocator: std.mem.Allocator, argv: []const []const u8, expe
     try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
 }
 
-/// Usage dumps: exit 1, empty stdout, stderr matches `z-fasta --help` stdout exactly.
+// Usage failures must reproduce the top-level help on stderr exactly.
 fn expectCliUsageFailure(allocator: std.mem.Allocator, argv: []const []const u8) !void {
     var threaded = std.Io.Threaded.init(allocator, .{});
     defer threaded.deinit();
@@ -516,6 +405,7 @@ fn expectCliUsageFailure(allocator: std.mem.Allocator, argv: []const []const u8)
 
 fn expectUnknownOptionRejected(allocator: std.mem.Allocator, argv: []const []const u8, unknown: []const u8) !void {
     const expected = try std.fmt.allocPrint(allocator, "error: unknown option: {s}\n", .{unknown});
+    defer allocator.free(expected);
     try expectCliFailure(allocator, argv, 1, expected);
 }
 
@@ -544,7 +434,7 @@ test "get help describes the request source contract" {
     try std.testing.expect(std.mem.indexOf(u8, result.stdout, "Names and BED input stream.") != null);
 }
 
-const get_usage_stderr =
+const GET_USAGE_STDERR =
     \\error: usage: z-fasta get <file.fasta> (<region>... | --names file.txt|- | --bed file.bed|-)
     \\
 ;
@@ -560,6 +450,18 @@ test "index rejects unknown options before and after FASTA path" {
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", fasta, unknown }, unknown);
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "-z", fasta }, "-z");
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "--low-mem", fasta }, "--low-mem");
+}
+
+test "index rejects multiple FASTA paths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    try expectCliFailure(
+        arena.allocator(),
+        &.{ ZFASTA_BIN, "index", "tests/data/simple.fasta", "tests/data/single.fasta" },
+        1,
+        "error: index accepts exactly one FASTA path\n",
+    );
 }
 
 test "get rejects unknown options before, between, and after positionals" {
@@ -624,7 +526,7 @@ test "names accepts the index name-length boundary in both formats" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const name = try allocator.alloc(u8, main.indexer.max_index_name_len);
+    const name = try allocator.alloc(u8, main.indexer.MAX_INDEX_NAME_LEN);
     @memset(name, 'A');
     var fasta = std.ArrayList(u8).empty;
     try fasta.ensureTotalCapacity(allocator, name.len + 4);
@@ -675,11 +577,13 @@ test "names rejects a request name above the index limit" {
 
     const names_path = try uniqueArtifactPath(allocator, "names-too-long", "txt");
     defer std.Io.Dir.cwd().deleteFile(io, names_path) catch {};
-    const names_file = try std.Io.Dir.cwd().createFile(io, names_path, .{});
-    const name = try allocator.alloc(u8, main.indexer.max_index_name_len + 1);
+    const name = try allocator.alloc(u8, main.indexer.MAX_INDEX_NAME_LEN + 1);
     @memset(name, 'A');
-    try std.Io.File.writeStreamingAll(names_file, io, name);
-    names_file.close(io);
+    {
+        const names_file = try std.Io.Dir.cwd().createFile(io, names_path, .{});
+        defer names_file.close(io);
+        try std.Io.File.writeStreamingAll(names_file, io, name);
+    }
 
     try expectCliFailure(
         allocator,
@@ -699,6 +603,18 @@ test "stats rejects unknown options before and after FASTA path" {
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", unknown, fasta }, unknown);
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", fasta, unknown }, unknown);
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", "--index-only", fasta }, "--index-only");
+}
+
+test "stats rejects multiple FASTA paths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+
+    try expectCliFailure(
+        arena.allocator(),
+        &.{ ZFASTA_BIN, "stats", "tests/data/simple.fasta", "tests/data/single.fasta" },
+        1,
+        "error: stats accepts exactly one FASTA path\n",
+    );
 }
 
 test "validate rejects unknown options before and after FASTA path" {
@@ -863,7 +779,7 @@ test "CLI failures: get usage, conflicts, and missing sequence" {
         }
     }
 
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta }, 1, get_usage_stderr);
+    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta }, 1, GET_USAGE_STDERR);
     try expectCliFailure(
         allocator,
         &.{ ZFASTA_BIN, "get", fasta, "missing" },
@@ -891,13 +807,15 @@ test "BED annotations describe final composed orientation" {
 
     const bed_path = try uniqueArtifactPath(allocator, "bed-annotation", "bed");
     defer std.Io.Dir.cwd().deleteFile(io, bed_path) catch {};
-    const bed_file = try std.Io.Dir.cwd().createFile(io, bed_path, .{});
-    try std.Io.File.writeStreamingAll(
-        bed_file,
-        io,
-        "seq1\t0\t5\tplus\t0\t+\nseq1\t0\t5\tminus\t0\t-\n",
-    );
-    bed_file.close(io);
+    {
+        const bed_file = try std.Io.Dir.cwd().createFile(io, bed_path, .{});
+        defer bed_file.close(io);
+        try std.Io.File.writeStreamingAll(
+            bed_file,
+            io,
+            "seq1\t0\t5\tplus\t0\t+\nseq1\t0\t5\tminus\t0\t-\n",
+        );
+    }
 
     try expectCliSuccess(
         allocator,
@@ -927,6 +845,18 @@ test "CLI failures: stats and validate usage errors" {
         &.{ ZFASTA_BIN, "validate", "--summary", "tests/data/simple.fasta" },
         1,
         "error: validate --summary requires --json\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--fix-format-only", "tests/data/simple.fasta" },
+        1,
+        "error: validate --fix-format-only requires --fix\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "-o", "zig-cache/test-artifacts/unused.fasta", "tests/data/simple.fasta" },
+        1,
+        "error: validate -o requires --fix\n",
     );
     try expectCliFailure(
         allocator,

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -106,8 +106,8 @@ test "parseRegion - name only with dots" {
 // ============================================================================
 
 test "loadIndex - .zfi file" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     var first_byte: [1]u8 = undefined;
     try std.testing.expectEqual(
@@ -136,21 +136,20 @@ test "loadIndex - .zfi file" {
 // ============================================================================
 
 test "resolveRegion - single region, full sequence" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r = resolveRegion(&idx, "seq1", 0);
+    const r = resolveRegion(&idx, "seq1");
     try std.testing.expectEqualStrings("seq1", r.name);
     try std.testing.expect(r.is_full);
     try std.testing.expectEqual(@as(u64, 24), r.num_bases);
-    try std.testing.expectEqual(@as(usize, 0), r.original_index);
 }
 
 test "resolveRegion - single region, sub-range" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r = resolveRegion(&idx, "seq1:1-12", 0);
+    const r = resolveRegion(&idx, "seq1:1-12");
     try std.testing.expectEqualStrings("seq1", r.name);
     try std.testing.expect(!r.is_full);
     try std.testing.expectEqual(@as(u64, 12), r.num_bases);
@@ -158,54 +157,34 @@ test "resolveRegion - single region, sub-range" {
     try std.testing.expectEqual(@as(u64, 12), r.display_end);
 }
 
-test "resolveRegion - original_index preserved" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
-
-    const r0 = resolveRegion(&idx, "seq1", 0);
-    const r1 = resolveRegion(&idx, "seq2", 1);
-    const r2 = resolveRegion(&idx, "seq1:1-5", 2);
-
-    try std.testing.expectEqual(@as(usize, 0), r0.original_index);
-    try std.testing.expectEqual(@as(usize, 1), r1.original_index);
-    try std.testing.expectEqual(@as(usize, 2), r2.original_index);
-}
-
 test "resolveRegion - end clamped silently" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     // seq1 has 24 bases; request end=9999 should clamp to 24
-    const r = resolveRegion(&idx, "seq1:1-9999", 0);
+    const r = resolveRegion(&idx, "seq1:1-9999");
     try std.testing.expectEqual(@as(u64, 24), r.num_bases);
     // display_end should be the user-supplied value (before clamping)
     try std.testing.expectEqual(@as(u64, 9999), r.display_end);
 }
 
-test "resolveRegion - byte offset for first base" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+test "resolveRegion - first base resolves one symbol" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    // seq1 starts immediately after ">seq1 test sequence\n"
-    // Verify start_byte is the offset of the first base character
-    const r = resolveRegion(&idx, "seq1:1-1", 0);
+    const r = resolveRegion(&idx, "seq1:1-1");
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-    // The byte at start_byte in fasta_data should be 'A'
-    try std.testing.expectEqual(@as(u8, 'A'), idx.fasta_data[r.start_byte]);
 }
 
-test "resolveRegion - duplicate region allowed, same start_byte" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+test "resolveRegion - duplicate region preserves geometry" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r0 = resolveRegion(&idx, "seq1:1-5", 0);
-    const r1 = resolveRegion(&idx, "seq1:1-5", 1);
+    const r0 = resolveRegion(&idx, "seq1:1-5");
+    const r1 = resolveRegion(&idx, "seq1:1-5");
 
-    // Same region twice should resolve to identical start_byte and num_bases
-    try std.testing.expectEqual(r0.start_byte, r1.start_byte);
+    try std.testing.expectEqual(r0.seq_offset, r1.seq_offset);
     try std.testing.expectEqual(r0.num_bases, r1.num_bases);
-    try std.testing.expectEqual(@as(usize, 0), r0.original_index);
-    try std.testing.expectEqual(@as(usize, 1), r1.original_index);
 }
 
 // ============================================================================
@@ -213,11 +192,11 @@ test "resolveRegion - duplicate region allowed, same start_byte" {
 // ============================================================================
 
 test "resolveRegion - open-ended region (NAME:START-) uses seq_len as end" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     // seq1 has 24 bases; NAME:13- should return bases 13..24 = 12 bases
-    const r = resolveRegion(&idx, "seq1:13-", 0);
+    const r = resolveRegion(&idx, "seq1:13-");
     try std.testing.expect(!r.is_full);
     try std.testing.expectEqual(@as(u64, 12), r.num_bases);
     // display_end should be seq_len (24), not null
@@ -225,52 +204,45 @@ test "resolveRegion - open-ended region (NAME:START-) uses seq_len as end" {
 }
 
 test "resolveRegion - single-base region" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r = resolveRegion(&idx, "seq1:1-1", 0);
+    const r = resolveRegion(&idx, "seq1:1-1");
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-    // First base of seq1 should be 'A'
-    try std.testing.expectEqual(@as(u8, 'A'), idx.fasta_data[r.start_byte]);
 }
 
 test "resolveRegion - last-base region" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    // seq1: ACGTACGTACGTACGTACGTACGT (24 bases), last base = 'T'
-    const r = resolveRegion(&idx, "seq1:24-24", 0);
+    const r = resolveRegion(&idx, "seq1:24-24");
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-    // Last base of seq1 should be 'T'
-    const byte = idx.fasta_data[r.start_byte];
-    try std.testing.expectEqual(@as(u8, 'T'), byte);
 }
 
 test "resolveRegion - cross-line region (starts line 1, ends line 2)" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
     // seq1 wraps at 12 bases per line; region 10-15 crosses the line boundary
-    const r = resolveRegion(&idx, "seq1:10-15", 0);
+    const r = resolveRegion(&idx, "seq1:10-15");
     try std.testing.expectEqual(@as(u64, 6), r.num_bases);
 }
 
-test "resolveRegion - full sequence start_byte points to first base character" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+test "resolveRegion - full and explicit ranges preserve geometry" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r_full = resolveRegion(&idx, "seq1", 0);
-    const r_range = resolveRegion(&idx, "seq1:1-24", 1);
-    // Both forms should land on the same start byte
-    try std.testing.expectEqual(r_full.start_byte, r_range.start_byte);
+    const r_full = resolveRegion(&idx, "seq1");
+    const r_range = resolveRegion(&idx, "seq1:1-24");
+    try std.testing.expectEqual(r_full.seq_offset, r_range.seq_offset);
     try std.testing.expectEqual(r_full.num_bases, r_range.num_bases);
 }
 
 test "resolveRegion - display_end before clamp, num_bases after clamp" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r = resolveRegion(&idx, "seq1:1-9999", 0);
+    const r = resolveRegion(&idx, "seq1:1-9999");
     // num_bases clamped to seq_len
     try std.testing.expectEqual(@as(u64, 24), r.num_bases);
     // display_end preserves user value
@@ -278,67 +250,59 @@ test "resolveRegion - display_end before clamp, num_bases after clamp" {
 }
 
 test "resolveRegion - proteome pipe-delimited name" {
-    var idx = main.index_format.loadIndex(io, "tests/data/proteome.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/proteome.fasta");
+    defer idx.deinit();
 
-    const r = resolveRegion(&idx, "sp|P12345|PROT_HUMAN:1-10", 0);
+    const r = resolveRegion(&idx, "sp|P12345|PROT_HUMAN:1-10");
     try std.testing.expectEqualStrings("sp|P12345|PROT_HUMAN", r.name);
     try std.testing.expectEqual(@as(u64, 10), r.num_bases);
 }
 
 test "resolveRegion - long header name (200-char sequence name)" {
-    var idx = main.index_format.loadIndex(io, "tests/data/edge_cases.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
+    defer idx.deinit();
 
     const long_name = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
-    const r = resolveRegion(&idx, long_name, 0);
+    const r = resolveRegion(&idx, long_name);
     try std.testing.expectEqualStrings(long_name, r.name);
     try std.testing.expect(r.is_full);
     try std.testing.expectEqual(@as(u64, 8), r.num_bases);
 }
 
-test "resolveRegion - lowercase bases preserved (byte offset still correct)" {
-    var idx = main.index_format.loadIndex(io, "tests/data/edge_cases.fasta");
-    defer idx.deinit(io);
+test "resolveRegion - lowercase record resolves" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
+    defer idx.deinit();
 
     // 'lowercase' in edge_cases.fasta: acgtACGTacgt (12 bases)
-    const r = resolveRegion(&idx, "lowercase:1-1", 0);
+    const r = resolveRegion(&idx, "lowercase:1-1");
     try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-    // First base should be 'a' (lowercase)
-    try std.testing.expectEqual(@as(u8, 'a'), idx.fasta_data[r.start_byte]);
 }
 
 test "resolveRegion - ordering: seq2 has higher file offset than seq1" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    const r1 = resolveRegion(&idx, "seq1:1-1", 0);
-    const r2 = resolveRegion(&idx, "seq2:1-1", 1);
-    // seq2 appears after seq1 in the file, so its start_byte must be greater
-    try std.testing.expect(r2.start_byte > r1.start_byte);
+    const r1 = resolveRegion(&idx, "seq1:1-1");
+    const r2 = resolveRegion(&idx, "seq2:1-1");
+    try std.testing.expect(r2.seq_offset > r1.seq_offset);
 }
 
-test "resolveRegion - reversed CLI order: seq2 before seq1 in args" {
-    var idx = main.index_format.loadIndex(io, "tests/data/simple.fasta");
-    defer idx.deinit(io);
+test "resolveRegion - file geometry is independent of request order" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-    // Even if caller passes seq2 first, original_index tracks CLI position
-    const r2 = resolveRegion(&idx, "seq2:1-1", 0); // position 0 in args
-    const r1 = resolveRegion(&idx, "seq1:1-1", 1); // position 1 in args
-    try std.testing.expectEqual(@as(usize, 0), r2.original_index);
-    try std.testing.expectEqual(@as(usize, 1), r1.original_index);
-    // But seq1 still has lower file offset
-    try std.testing.expect(r1.start_byte < r2.start_byte);
+    const r2 = resolveRegion(&idx, "seq2:1-1");
+    const r1 = resolveRegion(&idx, "seq1:1-1");
+    try std.testing.expect(r1.seq_offset < r2.seq_offset);
 }
 
 test "resolveRegion - nonstandard characters in sequence (stars/dashes)" {
-    var idx = main.index_format.loadIndex(io, "tests/data/edge_cases.fasta");
-    defer idx.deinit(io);
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
+    defer idx.deinit();
 
     // 'nonstandard' has ACG*-NACGT (10 chars)
-    const r = resolveRegion(&idx, "nonstandard:1-10", 0);
+    const r = resolveRegion(&idx, "nonstandard:1-10");
     try std.testing.expectEqual(@as(u64, 10), r.num_bases);
-    try std.testing.expectEqual(@as(u8, 'A'), idx.fasta_data[r.start_byte]);
 }
 
 // ============================================================================
@@ -381,8 +345,8 @@ fn writeZfi(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const 
 }
 
 fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(io, fasta_path);
-    defer idx.deinit(io);
+    var idx = try main.index_format.loadIndexChecked(std.testing.allocator, io, fasta_path);
+    defer idx.deinit();
 
     var out = std.Io.Writer.Allocating.init(allocator);
     main.getter.extractRegion(&idx, region, &out.writer);

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -1,167 +1,53 @@
-//! GET unit and CLI tests: region parsing, extraction, and failure-path subprocess checks.
+//! GET integration and CLI tests: region resolution, extraction, and failure paths.
 //!
 //! Includes indexed extraction and exact-exit CLI failure contracts.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const main = @import("main");
-const parseRegion = main.getter.parseRegion;
+const utility = @import("utility.zig");
 const resolveRegion = main.getter.resolveRegion;
 const io = std.testing.io;
 
-const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+const ZFASTA_BIN = utility.ZFASTA_BIN;
+const expectCliFailure = utility.expectCliFailure;
+const expectCliSuccess = utility.expectCliSuccess;
+const expectUnknownOptionRejected = utility.expectUnknownOptionRejected;
+const uniqueArtifactPath = utility.uniqueArtifactPath;
 
-// --- Region parsing tests ---
+test "[integration] - [region resolution]: preserves indexed coordinate geometry" {
+    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
+    defer idx.deinit();
 
-test "parseRegion recognizes names and coordinate suffixes" {
     const Case = struct {
-        input: []const u8,
-        name: []const u8,
-        start: u64 = 1,
-        end: ?u64 = null,
-        is_full: bool = true,
+        request: []const u8,
+        start: u64,
+        display_end: u64,
+        num_bases: u64,
+        is_full: bool = false,
     };
     const cases = [_]Case{
-        .{ .input = "chr1", .name = "chr1" },
-        .{ .input = "", .name = "" },
-        .{ .input = "chr1:100-200", .name = "chr1", .start = 100, .end = 200, .is_full = false },
-        .{ .input = "chr1:100-", .name = "chr1", .start = 100, .is_full = false },
-        .{
-            .input = "chromosome:GRCh38:1:1:248956422:1:100-200",
-            .name = "chromosome:GRCh38:1:1:248956422:1",
-            .start = 100,
-            .end = 200,
-            .is_full = false,
-        },
-        .{
-            .input = "chromosome:GRCh38:1:1:248956422:1",
-            .name = "chromosome:GRCh38:1:1:248956422:1",
-        },
-        .{ .input = "sp|P12345|PROT_NAME:1-50", .name = "sp|P12345|PROT_NAME", .end = 50, .is_full = false },
-        .{ .input = "chr1:1-1", .name = "chr1", .end = 1, .is_full = false },
-        .{ .input = "chr1:1000000-2000000", .name = "chr1", .start = 1_000_000, .end = 2_000_000, .is_full = false },
-        .{ .input = "KI270394.1:1-100", .name = "KI270394.1", .end = 100, .is_full = false },
-        .{ .input = "1:1", .name = "1:1" },
-        .{ .input = "chr1.1.2.3", .name = "chr1.1.2.3" },
+        .{ .request = "seq1", .start = 1, .display_end = 24, .num_bases = 24, .is_full = true },
+        .{ .request = "seq1:1-12", .start = 1, .display_end = 12, .num_bases = 12 },
+        .{ .request = "seq1:1-9999", .start = 1, .display_end = 9999, .num_bases = 24 },
+        .{ .request = "seq1:1-1", .start = 1, .display_end = 1, .num_bases = 1 },
+        .{ .request = "seq1:13-", .start = 13, .display_end = 24, .num_bases = 12 },
+        .{ .request = "seq1:24-24", .start = 24, .display_end = 24, .num_bases = 1 },
+        .{ .request = "seq1:1-24", .start = 1, .display_end = 24, .num_bases = 24 },
     };
 
     for (cases) |case| {
-        const region = parseRegion(case.input);
+        const resolved = resolveRegion(&idx, case.request);
 
-        try std.testing.expectEqualStrings(case.name, region.name);
-        try std.testing.expectEqual(case.start, region.start);
-        try std.testing.expectEqual(case.end, region.end);
-        try std.testing.expectEqual(case.is_full, region.is_full);
+        try std.testing.expectEqualStrings("seq1", resolved.name);
+        try std.testing.expectEqual(case.start, resolved.start);
+        try std.testing.expectEqual(case.display_end, resolved.display_end);
+        try std.testing.expectEqual(case.num_bases, resolved.num_bases);
+        try std.testing.expectEqual(case.is_full, resolved.is_full);
+        try std.testing.expectEqual(idx.records[0].seq_offset, resolved.seq_offset);
     }
 }
 
-// --- Index loading tests ---
-
-test "loadIndex - .zfi file" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    var first_byte: [1]u8 = undefined;
-    try std.testing.expectEqual(
-        @as(usize, 1),
-        try std.Io.File.readPositionalAll(idx.fasta_file, io, &first_byte, 0),
-    );
-    try std.testing.expectEqual(@as(u8, '>'), first_byte[0]);
-
-    try std.testing.expectEqual(@as(usize, 2), idx.records.len);
-    try std.testing.expectEqual(@as(u64, 24), idx.records[0].seq_len);
-    try std.testing.expectEqual(@as(u64, 12), idx.records[1].seq_len);
-
-    const seq1_idx = idx.lookupName("seq1");
-    try std.testing.expect(seq1_idx != null);
-    try std.testing.expectEqual(@as(usize, 0), seq1_idx.?);
-
-    const seq2_idx = idx.lookupName("seq2");
-    try std.testing.expect(seq2_idx != null);
-    try std.testing.expectEqual(@as(usize, 1), seq2_idx.?);
-
-    try std.testing.expectEqual(@as(?usize, null), idx.lookupName("nonexistent"));
-}
-
-// --- Multi-region resolution tests ---
-
-test "resolveRegion - single region, full sequence" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1");
-
-    try std.testing.expectEqualStrings("seq1", r.name);
-    try std.testing.expect(r.is_full);
-    try std.testing.expectEqual(@as(u64, 24), r.num_bases);
-}
-
-test "resolveRegion - single region, sub-range" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:1-12");
-
-    try std.testing.expectEqualStrings("seq1", r.name);
-    try std.testing.expect(!r.is_full);
-    try std.testing.expectEqual(@as(u64, 12), r.num_bases);
-    try std.testing.expectEqual(@as(u64, 1), r.start);
-    try std.testing.expectEqual(@as(u64, 12), r.display_end);
-}
-
-test "resolveRegion - end clamped silently" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:1-9999");
-
-    try std.testing.expectEqual(@as(u64, 24), r.num_bases);
-    try std.testing.expectEqual(@as(u64, 9999), r.display_end);
-}
-
-test "resolveRegion - first base resolves one symbol" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:1-1");
-
-    try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-}
-
-// --- resolveRegion edge cases ---
-
-test "resolveRegion - open-ended region (NAME:START-) uses seq_len as end" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:13-");
-
-    try std.testing.expect(!r.is_full);
-    try std.testing.expectEqual(@as(u64, 12), r.num_bases);
-    try std.testing.expectEqual(@as(u64, 24), r.display_end);
-}
-
-test "resolveRegion - last-base region" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r = resolveRegion(&idx, "seq1:24-24");
-
-    try std.testing.expectEqual(@as(u64, 1), r.num_bases);
-}
-
-test "resolveRegion - full and explicit ranges preserve geometry" {
-    var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/simple.fasta");
-    defer idx.deinit();
-
-    const r_full = resolveRegion(&idx, "seq1");
-    const r_range = resolveRegion(&idx, "seq1:1-24");
-
-    try std.testing.expectEqual(r_full.seq_offset, r_range.seq_offset);
-    try std.testing.expectEqual(r_full.num_bases, r_range.num_bases);
-}
-
-test "resolveRegion - proteome pipe-delimited name" {
+test "[integration] - [region resolution]: accepts a pipe-delimited protein identifier" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/proteome.fasta");
     defer idx.deinit();
 
@@ -171,7 +57,7 @@ test "resolveRegion - proteome pipe-delimited name" {
     try std.testing.expectEqual(@as(u64, 10), r.num_bases);
 }
 
-test "resolveRegion - long header name (200-char sequence name)" {
+test "[integration] - [region resolution]: accepts a 200-byte identifier" {
     var idx = main.index_format.loadIndex(std.testing.allocator, io, "tests/data/edge_cases.fasta");
     defer idx.deinit();
 
@@ -185,19 +71,10 @@ test "resolveRegion - long header name (200-char sequence name)" {
 
 // --- Index-backed get fixtures ---
 
-fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8, ext: []const u8) ![]u8 {
-    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.{s}", .{
-        stem,
-        nanos,
-        ext,
-    });
-}
-
 fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]const u8 {
     const path = try uniqueArtifactPath(allocator, stem, "fa");
+    errdefer allocator.free(path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
     const file = try std.Io.Dir.cwd().createFile(io, path, .{});
     defer file.close(io);
     try std.Io.File.writeStreamingAll(file, io, data);
@@ -230,7 +107,7 @@ fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, re
     return out.toOwnedSlice();
 }
 
-test "get extracts a region across uniform FASTA lines" {
+test "[property] - [get extraction]: zfi and fai match across uniform FASTA lines" {
     const data = @embedFile("data/simple.fasta");
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -238,21 +115,38 @@ test "get extracts a region across uniform FASTA lines" {
 
     const path = try writeFastaArtifact(allocator, "get-sam", data);
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{path});
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{path});
     defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
     try writeZfi(allocator, path, data, true);
 
-    const got = try captureExtractRegion(allocator, path, "seq1:10-15");
+    const zfi_output = try captureExtractRegion(allocator, path, "seq1:10-15");
     const expected =
         \\>seq1:10-15
         \\CGTACG
         \\
     ;
-    try std.testing.expectEqualStrings(expected, got);
+    try std.testing.expectEqualStrings(expected, zfi_output);
+
+    try std.Io.Dir.cwd().deleteFile(io, zfi_path);
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
+        defer fai_file.close(io);
+        try std.Io.File.writeStreamingAll(
+            fai_file,
+            io,
+            "seq1\t24\t20\t12\t13\nseq2\t12\t69\t12\t13\n",
+        );
+    }
+    const fai_output = try captureExtractRegion(allocator, path, "seq1:10-15");
+
+    try std.testing.expectEqualStrings(expected, fai_output);
+    try std.testing.expectEqualStrings(zfi_output, fai_output);
 }
 
-test "get preserves lowercase and nonstandard sequence bytes" {
+test "[integration] - [get extraction]: preserves lowercase and nonstandard bytes" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -264,7 +158,7 @@ test "get preserves lowercase and nonstandard sequence bytes" {
     try std.testing.expectEqualStrings(">nonstandard\nACG*-NACGT\n", nonstandard);
 }
 
-test "get on messy mixed_widths after indexing" {
+test "[integration] - [get extraction]: extracts across non-uniform FASTA lines" {
     const data =
         \\>mixed_widths internal line widths vary
         \\AAAACCCCGGGG
@@ -295,7 +189,7 @@ test "get on messy mixed_widths after indexing" {
     try std.testing.expectEqualStrings(expected, output);
 }
 
-test "CLI get selects the first empty identifier through zfi and fai" {
+test "[cli] - [get]: selects the first empty identifier through zfi and fai" {
     const data = ">\nAAAA\n>\nCCCCCC\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -320,96 +214,7 @@ test "CLI get selects the first empty identifier through zfi and fai" {
     try expectCliSuccess(allocator, &.{ ZFASTA_BIN, "get", fasta_path, "" }, ">\nAAAA\n");
 }
 
-// Hard CLI failures require exact exit code and stderr with no partial stdout.
-fn expectCliFailure(
-    allocator: std.mem.Allocator,
-    argv: []const []const u8,
-    exit_code: u8,
-    expected_stderr: []const u8,
-) !void {
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const spawn_io = threaded.io();
-
-    const result = try std.process.run(allocator, spawn_io, .{
-        .argv = argv,
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .exited => |code| try std.testing.expectEqual(exit_code, code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqual(@as(usize, 0), result.stdout.len);
-    try std.testing.expectEqualStrings(expected_stderr, result.stderr);
-}
-
-fn expectCliSuccess(allocator: std.mem.Allocator, argv: []const []const u8, expected_stdout: []const u8) !void {
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-
-    const result = try std.process.run(allocator, threaded.io(), .{
-        .argv = argv,
-        .stdout_limit = .limited(128 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqualStrings(expected_stdout, result.stdout);
-    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
-}
-
-// Usage failures must reproduce the top-level help on stderr exactly.
-fn expectCliUsageFailure(allocator: std.mem.Allocator, argv: []const []const u8) !void {
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const spawn_io = threaded.io();
-
-    const help = try std.process.run(allocator, spawn_io, .{
-        .argv = &.{ ZFASTA_BIN, "--help" },
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(help.stdout);
-    defer allocator.free(help.stderr);
-    switch (help.term) {
-        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqual(@as(usize, 0), help.stderr.len);
-    try std.testing.expect(help.stdout.len > 0);
-
-    const result = try std.process.run(allocator, spawn_io, .{
-        .argv = argv,
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .exited => |code| try std.testing.expectEqual(@as(u8, 1), code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqual(@as(usize, 0), result.stdout.len);
-    try std.testing.expectEqualStrings(help.stdout, result.stderr);
-}
-
-fn expectUnknownOptionRejected(allocator: std.mem.Allocator, argv: []const []const u8, unknown: []const u8) !void {
-    const expected = try std.fmt.allocPrint(allocator, "error: unknown option: {s}\n", .{unknown});
-    defer allocator.free(expected);
-    try expectCliFailure(allocator, argv, 1, expected);
-}
-
-test "get help describes the request source contract" {
+test "[cli] - [get help]: describes the request source contract" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -439,32 +244,7 @@ const GET_USAGE_STDERR =
     \\
 ;
 
-test "index rejects unknown options before and after FASTA path" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    const fasta = "tests/data/simple.fasta";
-    const unknown = "--not-a-flag";
-
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", unknown, fasta }, unknown);
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", fasta, unknown }, unknown);
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "-z", fasta }, "-z");
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "--low-mem", fasta }, "--low-mem");
-}
-
-test "index rejects multiple FASTA paths" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    try expectCliFailure(
-        arena.allocator(),
-        &.{ ZFASTA_BIN, "index", "tests/data/simple.fasta", "tests/data/single.fasta" },
-        1,
-        "error: index accepts exactly one FASTA path\n",
-    );
-}
-
-test "get rejects unknown options before, between, and after positionals" {
+test "[cli] - [get]: rejects unknown options regardless of position" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -478,7 +258,7 @@ test "get rejects unknown options before, between, and after positionals" {
     try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "get", fasta, "--bed", "tests/data/simple.bed", "--chunk-size=-1" }, "--chunk-size=-1");
 }
 
-test "get rejects repeated request source flags" {
+test "[cli] - [get]: rejects repeated request source flags" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -498,7 +278,7 @@ test "get rejects repeated request source flags" {
     );
 }
 
-test "get rejects mixed request source families" {
+test "[cli] - [get]: rejects mixed request source families" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -510,7 +290,7 @@ test "get rejects mixed request source families" {
     try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta, "--names", "ids.txt", "--bed", "regions.bed" }, 1, expected);
 }
 
-test "get rejects strand handling outside BED input" {
+test "[cli] - [get]: rejects strand handling outside BED input" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -521,7 +301,7 @@ test "get rejects strand handling outside BED input" {
     try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta, "--names", "ids.txt", "--honor-strand" }, 1, expected);
 }
 
-test "names accepts the index name-length boundary in both formats" {
+test "[cli] - [get names]: accepts the index name-length boundary in both formats" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -570,7 +350,7 @@ test "names accepts the index name-length boundary in both formats" {
     try expectCliSuccess(allocator, &.{ ZFASTA_BIN, "get", fai_fasta, "--names", names_path }, expected.items);
 }
 
-test "names rejects a request name above the index limit" {
+test "[cli] - [get names]: rejects a request name above the index limit" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -593,65 +373,17 @@ test "names rejects a request name above the index limit" {
     );
 }
 
-test "stats rejects unknown options before and after FASTA path" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    const fasta = "tests/data/simple.fasta";
-    const unknown = "--not-a-flag";
-
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", unknown, fasta }, unknown);
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", fasta, unknown }, unknown);
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", "--index-only", fasta }, "--index-only");
-}
-
-test "stats rejects multiple FASTA paths" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    try expectCliFailure(
-        arena.allocator(),
-        &.{ ZFASTA_BIN, "stats", "tests/data/simple.fasta", "tests/data/single.fasta" },
-        1,
-        "error: stats accepts exactly one FASTA path\n",
-    );
-}
-
-test "validate rejects unknown options before and after FASTA path" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    const fasta = "tests/data/simple.fasta";
-    const unknown = "--not-a-flag";
-
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "validate", unknown, fasta }, unknown);
-    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "validate", fasta, unknown }, unknown);
-}
-
-test "CLI failures: missing command and missing subcommand args print usage on stderr" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    try expectCliUsageFailure(allocator, &.{ZFASTA_BIN});
-    try expectCliUsageFailure(allocator, &.{ ZFASTA_BIN, "index" });
-    try expectCliUsageFailure(allocator, &.{ ZFASTA_BIN, "not-a-command" });
-}
-
-test "CLI failures: missing FASTA path is exit 1 with exact stderr" {
+test "[cli] - [get]: missing FASTA path returns an exact error" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
     const missing = "tests/data/definitely-missing-cli-failure.fasta";
     const expected = "error: file not found: tests/data/definitely-missing-cli-failure.fasta\n";
 
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "index", missing }, 1, expected);
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", missing }, 1, expected);
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "validate", missing }, 1, expected);
     try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", missing, "seq1" }, 1, expected);
 }
 
-test "get validates FASTA and sidecar before opening a request source" {
+test "[cli] - [get]: validates FASTA and sidecar before request input" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -670,7 +402,7 @@ test "get validates FASTA and sidecar before opening a request source" {
     );
 }
 
-test "CLI failures: invalid present zfi blocks valid fai for get and stats" {
+test "[cli] - [get index selection]: invalid zfi blocks a valid fai" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -696,10 +428,9 @@ test "CLI failures: invalid present zfi blocks valid fai for get and stats" {
     const expected = try std.fmt.allocPrint(allocator, "error: corrupt index file for: {s}\n", .{fasta});
     try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta, "seq" }, 1, expected);
     try expectCliFailure(allocator, &.{ ZFASTA_BIN, "get", fasta, "--names", "missing.txt" }, 1, expected);
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", fasta }, 1, expected);
 }
 
-test "streamed names failures suppress summary and expose only valid output prefixes" {
+test "[cli] - [get names]: failures preserve only valid output prefixes" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -747,12 +478,13 @@ test "streamed names failures suppress summary and expose only valid output pref
     try std.testing.expect(result.stdout.len > 0);
     try std.testing.expectEqualStrings("error: sequence not found: missing\n", result.stderr);
     const one_output = ">seq1\nACGTACGTACGTACGTACGTACGT\n";
+    try std.testing.expect(result.stdout.len <= one_output.len * 65536);
     for (result.stdout, 0..) |byte, i| {
         try std.testing.expectEqual(one_output[i % one_output.len], byte);
     }
 }
 
-test "CLI failures: get usage, conflicts, and missing sequence" {
+test "[cli] - [get]: rejects invalid requests, missing names, and transform conflicts" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -788,6 +520,24 @@ test "CLI failures: get usage, conflicts, and missing sequence" {
     );
     try expectCliFailure(
         allocator,
+        &.{ ZFASTA_BIN, "get", fasta, "seq1:0-1" },
+        1,
+        "error: start position must be >= 1\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "get", fasta, "seq1:25-25" },
+        1,
+        "error: start position 25 exceeds sequence length 24\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "get", fasta, "seq1:10-9" },
+        1,
+        "error: end position must be >= start position\n",
+    );
+    try expectCliFailure(
+        allocator,
         &.{ ZFASTA_BIN, "get", fasta, "seq1", "--annotate-rc" },
         1,
         "error: --annotate-rc requires a transform or --strand-aware BED input\n",
@@ -800,7 +550,7 @@ test "CLI failures: get usage, conflicts, and missing sequence" {
     );
 }
 
-test "BED annotations describe final composed orientation" {
+test "[cli] - [get BED]: annotations describe the composed orientation" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -827,69 +577,4 @@ test "BED annotations describe final composed orientation" {
         &.{ ZFASTA_BIN, "get", "tests/data/simple.fasta", "--bed", bed_path, "--strand-aware", "--rc", "--annotate-rc" },
         ">seq1:1-5 (reverse complement)\nTACGT\n>seq1:1-5\nACGTA\n",
     );
-}
-
-test "CLI failures: stats and validate usage errors" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    try expectCliFailure(
-        allocator,
-        &.{ ZFASTA_BIN, "stats" },
-        1,
-        "error: usage: z-fasta stats <file.fasta>\n",
-    );
-    try expectCliFailure(
-        allocator,
-        &.{ ZFASTA_BIN, "validate", "--summary", "tests/data/simple.fasta" },
-        1,
-        "error: validate --summary requires --json\n",
-    );
-    try expectCliFailure(
-        allocator,
-        &.{ ZFASTA_BIN, "validate", "--fix-format-only", "tests/data/simple.fasta" },
-        1,
-        "error: validate --fix-format-only requires --fix\n",
-    );
-    try expectCliFailure(
-        allocator,
-        &.{ ZFASTA_BIN, "validate", "-o", "zig-cache/test-artifacts/unused.fasta", "tests/data/simple.fasta" },
-        1,
-        "error: validate -o requires --fix\n",
-    );
-    try expectCliFailure(
-        allocator,
-        &.{ ZFASTA_BIN, "validate" },
-        1,
-        "error: usage: z-fasta validate [options] <file.fasta>\n",
-    );
-}
-
-test "CLI validate warnings: exit 2, empty stderr, exact WARNING stdout" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const path = try writeFastaArtifact(allocator, "cli-validate-warn", ">empty_rec\n");
-    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
-
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const spawn_io = threaded.io();
-
-    const result = try std.process.run(allocator, spawn_io, .{
-        .argv = &.{ ZFASTA_BIN, "validate", path },
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .exited => |code| try std.testing.expectEqual(@as(u8, 2), code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
-    try std.testing.expectEqualStrings("WARNING: line 1: empty sequence 'empty_rec'\n", result.stdout);
 }

--- a/tests/test_get.zig
+++ b/tests/test_get.zig
@@ -517,6 +517,92 @@ test "[cli] - [get]: rejects invalid requests, missing names, and transform conf
     );
 }
 
+test "[cli] - [get BED]: converts coordinates and skips metadata lines" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const bed_path = try uniqueArtifactPath(allocator, "bed-parser-success", "bed");
+    defer std.Io.Dir.cwd().deleteFile(io, bed_path) catch {};
+    {
+        const bed_file = try std.Io.Dir.cwd().createFile(io, bed_path, .{});
+        defer bed_file.close(io);
+        try std.Io.File.writeStreamingAll(
+            bed_file,
+            io,
+            "track name=ignored\n# ignored\nbrowser position chr1:1-10\nseq1\t0\t1\nseq1\t5\t9\r\n",
+        );
+    }
+
+    try expectCliSuccess(
+        allocator,
+        &.{ ZFASTA_BIN, "get", "tests/data/simple.fasta", "--bed", bed_path },
+        ">seq1:1-1\nA\n>seq1:6-9\nCGTA\n",
+    );
+}
+
+test "[cli] - [get BED]: reports parser boundary errors" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const bed_path = try uniqueArtifactPath(allocator, "bed-parser-failures", "bed");
+    defer std.Io.Dir.cwd().deleteFile(io, bed_path) catch {};
+    const Case = struct {
+        line: []const u8,
+        expected: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .line = "\t0\t1\n", .expected = "error: invalid BED line 1: missing chrom\n" },
+        .{ .line = "seq1\n", .expected = "error: invalid BED line 1: missing start\n" },
+        .{ .line = "seq1\t0\n", .expected = "error: invalid BED line 1: missing end\n" },
+        .{ .line = "seq1\t-0\t10\n", .expected = "error: invalid BED line 1: invalid start\n" },
+        .{ .line = "seq1\t+1\t10\n", .expected = "error: invalid BED line 1: invalid start\n" },
+        .{ .line = "seq1\t1_0\t20\n", .expected = "error: invalid BED line 1: invalid start\n" },
+        .{ .line = "seq1\t18446744073709551616\t20\n", .expected = "error: invalid BED line 1: invalid start\n" },
+        .{ .line = "seq1\t0\t+10\n", .expected = "error: invalid BED line 1: invalid end\n" },
+        .{ .line = "seq1\t0\t1_0\n", .expected = "error: invalid BED line 1: invalid end\n" },
+        .{ .line = "seq1\t0\t18446744073709551616\n", .expected = "error: invalid BED line 1: invalid end\n" },
+        .{ .line = "seq1\t10\t10\n", .expected = "error: invalid BED line 1: end must be greater than start\n" },
+        .{ .line = "seq1\t10\t9\n", .expected = "error: invalid BED line 1: end must be greater than start\n" },
+        .{
+            .line = "seq1\t18446744073709551614\t18446744073709551615\n",
+            .expected = "error: start position 18446744073709551615 exceeds sequence length 24\n",
+        },
+    };
+
+    for (cases) |case| {
+        {
+            const bed_file = try std.Io.Dir.cwd().createFile(io, bed_path, .{ .truncate = true });
+            defer bed_file.close(io);
+            try std.Io.File.writeStreamingAll(bed_file, io, case.line);
+        }
+        try expectCliFailure(
+            allocator,
+            &.{ ZFASTA_BIN, "get", "tests/data/simple.fasta", "--bed", bed_path },
+            1,
+            case.expected,
+        );
+    }
+
+    {
+        const bed_file = try std.Io.Dir.cwd().createFile(io, bed_path, .{ .truncate = true });
+        defer bed_file.close(io);
+        try std.Io.File.writeStreamingAll(bed_file, io, "seq1\t0\t1\tname\t0\t?\n");
+    }
+    try expectCliSuccess(
+        allocator,
+        &.{ ZFASTA_BIN, "get", "tests/data/simple.fasta", "--bed", bed_path },
+        ">seq1:1-1\nA\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "get", "tests/data/simple.fasta", "--bed", bed_path, "--strand-aware" },
+        1,
+        "error: invalid BED line 1: invalid strand\n",
+    );
+}
+
 test "[cli] - [get BED]: annotations describe the composed orientation" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -6,7 +6,12 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const main = @import("main");
-const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+const utility = @import("utility.zig");
+const ZFASTA_BIN = utility.ZFASTA_BIN;
+const expectCliFailure = utility.expectCliFailure;
+const expectCliResult = utility.expectCliResult;
+const expectUnknownOptionRejected = utility.expectUnknownOptionRejected;
+const uniqueArtifactPath = utility.uniqueArtifactPath;
 const scanFaiData = main.indexer.scanFaiData;
 const INDEX_READ_BUFFER_SIZE = main.indexer.INDEX_READ_BUFFER_SIZE;
 const IndexRecord = main.index_format.IndexRecord;
@@ -66,22 +71,32 @@ fn writeFastaAndRawZfi(allocator: std.mem.Allocator, stem: []const u8, fasta: []
     return .{ .fasta_path = fasta_path, .zfi_path = zfi_path };
 }
 
+fn writeFastaAndFai(allocator: std.mem.Allocator, stem: []const u8, fasta: []const u8, fai: []const u8) !struct { fasta_path: []u8, fai_path: []u8 } {
+    const fasta_path = try uniqueArtifactPath(allocator, stem, "fa");
+    errdefer allocator.free(fasta_path);
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    errdefer allocator.free(fai_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    errdefer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, fasta);
+    }
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
+        defer fai_file.close(io);
+        try std.Io.File.writeStreamingAll(fai_file, io, fai);
+    }
+    return .{ .fasta_path = fasta_path, .fai_path = fai_path };
+}
+
 fn supportsPosixFutimens() bool {
     return switch (builtin.os.tag) {
         .linux, .dragonfly, .freebsd, .netbsd, .openbsd, .illumos, .macos, .ios, .tvos, .watchos, .visionos, .driverkit, .maccatalyst => true,
         else => false,
     };
-}
-
-fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8, ext: []const u8) ![]u8 {
-    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.{s}", .{
-        stem,
-        nanos,
-        ext,
-    });
 }
 
 fn uniqueArtifactDirPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
@@ -147,7 +162,8 @@ fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     };
     defer file.close(io);
     const stat = try file.stat(io);
-    const data = try allocator.alloc(u8, @intCast(stat.size));
+    const size = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
+    const data = try allocator.alloc(u8, size);
     errdefer allocator.free(data);
     const bytes_read = try std.Io.File.readPositionalAll(file, io, data, 0);
     if (bytes_read != data.len) return error.UnexpectedEndOfFile;
@@ -191,6 +207,25 @@ fn scanFaiForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !vo
     var storage: [256]u8 = undefined;
     var output = std.Io.Writer.fixed(&storage);
     _ = try scanFaiData(data, &output, true, allocator);
+}
+
+fn fuzzFastaScanner(_: void, smith: *std.testing.Smith) !void {
+    var storage: [512]u8 = undefined;
+    const data = storage[0..smith.slice(&storage)];
+    var index = try main.indexer.scanZfiData(data, true, std.testing.allocator);
+    defer index.deinit(std.testing.allocator);
+
+    for (index.records.items) |record| {
+        const data_len: u64 = data.len;
+        try std.testing.expect(record.seq_offset < data_len);
+        try std.testing.expect(record.seq_len <= data_len - record.seq_offset);
+        try std.testing.expect(record.line_bases > 0);
+        try std.testing.expect(record.line_bytes >= record.line_bases);
+        const name_offset = std.math.cast(usize, record.name_offset) orelse return error.TestUnexpectedResult;
+        try std.testing.expect(name_offset <= index.name_blob.items.len);
+        if (name_offset > index.name_blob.items.len) return error.TestUnexpectedResult;
+        try std.testing.expect(record.name_len <= index.name_blob.items.len - name_offset);
+    }
 }
 
 // In-repo fixtures are required; absence is a test failure, not a skip.
@@ -371,27 +406,84 @@ fn expectCorruptFaiFixture(allocator: std.mem.Allocator, stem: []const u8) !void
     const fai_data = try readTestFile(allocator, src_fai);
     defer allocator.free(fai_data);
 
-    const fasta_path = try uniqueArtifactPath(allocator, "gates-fai", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
-    {
-        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-        defer fai_file.close(io);
-        try std.Io.File.writeStreamingAll(fai_file, io, fai_data);
-    }
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
+    const paths = try writeFastaAndFai(allocator, "gates-fai", fasta_data, fai_data);
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 // --- FASTA reader tests ---
 
-test "FASTA scan records names and geometry" {
+test "[cli] - [index]: rejects unknown options regardless of position" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const fasta = "tests/data/simple.fasta";
+
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "--not-a-flag", fasta }, "--not-a-flag");
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", fasta, "--not-a-flag" }, "--not-a-flag");
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "-z", fasta }, "-z");
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "index", "--low-mem", fasta }, "--low-mem");
+}
+
+test "[cli] - [index]: rejects multiple and nonexistent FASTA paths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "index", "tests/data/simple.fasta", "tests/data/single.fasta" },
+        1,
+        "error: index accepts exactly one FASTA path\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "index", "tests/data/definitely-missing-cli-failure.fasta" },
+        1,
+        "error: file not found: tests/data/definitely-missing-cli-failure.fasta\n",
+    );
+}
+
+test "[cli] - [index]: writes ZFI and applies duplicate-name policy" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const fasta_path = try uniqueArtifactPath(allocator, "index-cli-success", "fa");
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{zfi_path});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, ">dup\nA\n>dup\nCC\n");
+    }
+
+    const dedup_message = try std.fmt.allocPrint(allocator, "wrote {s} (1 sequences)\n", .{zfi_path});
+    try expectCliResult(allocator, &.{ ZFASTA_BIN, "index", fasta_path }, 0, "", dedup_message);
+    {
+        var idx = try loadIndexChecked(std.testing.allocator, io, fasta_path);
+        defer idx.deinit();
+        try std.testing.expectEqual(@as(usize, 1), idx.records.len);
+        try std.testing.expectEqual(@as(u64, 1), idx.records[0].seq_len);
+    }
+
+    const all_message = try std.fmt.allocPrint(allocator, "wrote {s} (2 sequences)\n", .{zfi_path});
+    try expectCliResult(allocator, &.{ ZFASTA_BIN, "index", "--no-dedup", fasta_path }, 0, "", all_message);
+    {
+        var idx = try loadIndexChecked(std.testing.allocator, io, fasta_path);
+        defer idx.deinit();
+        try std.testing.expectEqual(@as(usize, 2), idx.records.len);
+        try std.testing.expectEqual(@as(u64, 1), idx.records[0].seq_len);
+        try std.testing.expectEqual(@as(u64, 2), idx.records[1].seq_len);
+    }
+    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, tmp_path, .{}));
+}
+
+test "[unit] - [FASTA scanner]: records names and fixed-width geometry" {
     const data = ">seq1\nACGT\n>seq2\nGGGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -408,7 +500,7 @@ test "FASTA scan records names and geometry" {
     try std.testing.expectEqual(@as(u32, 5), records.items[0].line_bytes);
 }
 
-test "FASTA scan retains identifiers and discards descriptions" {
+test "[unit] - [FASTA scanner]: retains identifiers and discards descriptions" {
     const data = ">myseq some description here\nACGT\n>sp|P12345|PROT_NAME OS=Human\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -419,79 +511,38 @@ test "FASTA scan retains identifiers and discards descriptions" {
     try std.testing.expectEqualStrings("sp|P12345|PROT_NAME", records.items[1].getName(data));
 }
 
-test "scanRecordsForTest multiline sequence" {
-    const data = ">seq1\nAAAA\nBBBB\nCCCC\n";
+test "[property] - [FASTA scanner]: preserves counts and geometry across line layouts" {
+    const Case = struct {
+        data: []const u8,
+        seq_len: u64,
+        line_bases: ?u32 = null,
+        line_bytes: ?u32 = null,
+    };
+    const cases = [_]Case{
+        .{ .data = ">seq1\nAAAA\nBBBB\nCCCC\n", .seq_len = 12, .line_bases = 4, .line_bytes = 5 },
+        .{ .data = ">chrSynthetic\nAAAAAAAA\nCCCCCCCC\nGGGG\n", .seq_len = 20, .line_bases = 8, .line_bytes = 9 },
+        .{ .data = ">seq1\nACGTACGT  \nACGT\n", .seq_len = 12 },
+        .{ .data = ">a\nAAAA\n>next\n", .seq_len = 4 },
+        .{ .data = ">seq\nACGT    \nACGTACGT\n", .seq_len = 12 },
+        .{ .data = ">seq1\r\nACGT\r\n", .seq_len = 4, .line_bases = 4, .line_bytes = 6 },
+    };
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-
-    const rec = records.items[0];
-    try std.testing.expectEqual(@as(u64, 12), rec.seq_len);
-    try std.testing.expectEqual(@as(u32, 4), rec.line_bases);
-    try std.testing.expectEqual(@as(u32, 5), rec.line_bytes);
+    for (cases) |case| {
+        const records = try scanRecordsForTest(arena.allocator(), case.data);
+        try std.testing.expectEqual(@as(usize, 1), records.items.len);
+        try std.testing.expectEqual(case.seq_len, records.items[0].seq_len);
+        if (case.line_bases) |expected| {
+            try std.testing.expectEqual(expected, records.items[0].line_bases);
+        }
+        if (case.line_bytes) |expected| {
+            try std.testing.expectEqual(expected, records.items[0].line_bytes);
+        }
+    }
 }
 
-test "scanRecordsForTest counts wrapped final short line with trailing newline correctly" {
-    const data = ">chrSynthetic\nAAAAAAAA\nCCCCCCCC\nGGGG\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-
-    const rec = records.items[0];
-    try std.testing.expectEqual(@as(u64, 20), rec.seq_len);
-    try std.testing.expectEqual(@as(u32, 8), rec.line_bases);
-    try std.testing.expectEqual(@as(u32, 9), rec.line_bytes);
-}
-
-test "scanRecordsForTest counts trailing whitespace lines via base scan fallback" {
-    const data = ">seq1\nACGTACGT  \nACGT\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-    try std.testing.expectEqual(@as(u64, 12), records.items[0].seq_len);
-}
-
-test "scanRecordsForTest counts record with trailing newline before next header" {
-    const data = ">a\nAAAA\n>next\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-    try std.testing.expectEqual(@as(u64, 4), records.items[0].seq_len);
-}
-
-test "scanRecordsForTest cross-checks non-dense first line against countBases" {
-    const data = ">seq\nACGT    \nACGTACGT\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-    try std.testing.expectEqual(@as(u64, 12), records.items[0].seq_len);
-}
-
-test "scanRecordsForTest handles CRLF line endings" {
-    const data = ">seq1\r\nACGT\r\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(arena.allocator(), data);
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-
-    const rec = records.items[0];
-    try std.testing.expectEqual(@as(u64, 4), rec.seq_len);
-    try std.testing.expectEqual(@as(u32, 4), rec.line_bases);
-    try std.testing.expectEqual(@as(u32, 6), rec.line_bytes);
-}
-
-test "scanRecordsForTest skips empty sequences (matches samtools)" {
+test "[edge] - [FASTA scanner]: skips empty sequences" {
     const data = ">empty\n>next\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -501,7 +552,7 @@ test "scanRecordsForTest skips empty sequences (matches samtools)" {
     try std.testing.expectEqualStrings("next", records.items[0].getName(data));
 }
 
-test "scanRecordsForTest skips duplicate names (matches samtools)" {
+test "[edge] - [FASTA scanner]: keeps the first duplicate name" {
     const data = ">dup\nAAAA\n>other\nCCCC\n>dup\nGGGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -512,7 +563,7 @@ test "scanRecordsForTest skips duplicate names (matches samtools)" {
     try std.testing.expectEqualStrings("other", records.items[1].getName(data));
 }
 
-test "FAI dedup keeps first occurrence and distinct names" {
+test "[edge] - [FAI scanner]: keeps the first duplicate and all distinct names" {
     const data = ">dup\nAAAA\n>other\nCCCC\n>dup\nGGGG\n>also\nTTTT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -523,12 +574,13 @@ test "FAI dedup keeps first occurrence and distinct names" {
     const count = try scanFaiData(data, &fai.writer, true, allocator);
 
     try std.testing.expectEqual(@as(u32, 3), count);
-    try std.testing.expectEqual(@as(usize, 1), std.mem.count(u8, fai.written(), "dup\t"));
-    try std.testing.expect(std.mem.indexOf(u8, fai.written(), "other\t") != null);
-    try std.testing.expect(std.mem.indexOf(u8, fai.written(), "also\t") != null);
+    try std.testing.expectEqualStrings(
+        "dup\t4\t5\t4\t5\nother\t4\t17\t4\t5\nalso\t4\t38\t4\t5\n",
+        fai.written(),
+    );
 }
 
-test "index scans release allocations on every failure path" {
+test "[failure] - [index scanners]: release partial allocations" {
     const data = ">alpha\nAAAA\n>beta\nCCCC\n>alpha\nGGGG\n";
 
     try std.testing.checkAllAllocationFailures(
@@ -543,9 +595,19 @@ test "index scans release allocations on every failure path" {
     );
 }
 
+test "[fuzz] - [FASTA scanner]: returns bounded records for arbitrary bytes" {
+    try std.testing.fuzz({}, fuzzFastaScanner, .{ .corpus = &.{
+        "",
+        ">a\nA\n",
+        ">a description\r\nAC\r\nGT",
+        ">a\nAAA\nCC\nGGGG\n",
+        ">bad\xffname\nA\x00C\n",
+    } });
+}
+
 // --- ZFI wire format ---
 
-test "writeZfiIndexFile creates valid production layout" {
+test "[integration] - [ZFI writer]: creates the production layout" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -579,13 +641,13 @@ test "writeZfiIndexFile creates valid production layout" {
     );
 }
 
-test "zfi wire structs retain frozen sizes" {
+test "[unit] - [ZFI format]: retains frozen wire sizes" {
     try std.testing.expectEqual(@as(usize, 16), @sizeOf(ZfiHeader));
     try std.testing.expectEqual(@as(usize, 40), @sizeOf(IndexRecord));
     try std.testing.expectEqual(@as(usize, 32), @sizeOf(main.index_format.SideTableLine));
 }
 
-test "zfi wire encoders match asBytes for frozen little-endian layout" {
+test "[property] - [ZFI format]: encoders match the frozen little-endian layout" {
     const header = ZfiHeader{
         .magic = ZFI_MAGIC,
         .record_count = 0x01020304,
@@ -619,7 +681,7 @@ test "zfi wire encoders match asBytes for frozen little-endian layout" {
     try std.testing.expectEqual(@as(u64, 0x0102030405060708), std.mem.readInt(u64, footer[4..12], .little));
 }
 
-test "zfiIndexToBytes matches encodeZfiHeader prefix and LE side-table count" {
+test "[property] - [ZFI writer]: emits encoded records and side-table counts" {
     const data = ">seq\nAAA\nCCCC\nGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -651,7 +713,7 @@ test "zfiIndexToBytes matches encodeZfiHeader prefix and LE side-table count" {
     );
 }
 
-test "scanZfiData marks non-uniform records and appends side table" {
+test "[unit] - [ZFI scanner]: stores side tables for non-uniform records" {
     const data = ">seq\nAAA\nCCCC\nGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -674,7 +736,7 @@ test "scanZfiData marks non-uniform records and appends side table" {
     );
 }
 
-test "scanZfiReader zfi loads record names" {
+test "[integration] - [ZFI loader]: resolves embedded record names" {
     const data = @embedFile("data/simple.fasta");
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -695,7 +757,7 @@ test "scanZfiReader zfi loads record names" {
     try std.testing.expectEqual(@as(?usize, 1), idx.lookupName("seq2"));
 }
 
-test "indexing crosses the production read boundary" {
+test "[edge] - [index scanners]: cross the production read boundary" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -736,7 +798,7 @@ test "indexing crosses the production read boundary" {
     try std.testing.expectEqualStrings("seq2", second_name);
 }
 
-test "indexing handles a header name split at the production read boundary" {
+test "[edge] - [index scanners]: preserve a header split at the read boundary" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -767,7 +829,7 @@ test "indexing handles a header name split at the production read boundary" {
     try std.testing.expectEqual(@as(u64, chunk + 5), index.records.items[1].seq_offset);
 }
 
-test "reader-size matrix matches both formats across token boundaries" {
+test "[property] - [index scanners]: reader sizes preserve both formats across token boundaries" {
     const data = ">alpha\tlong description\r\nACGT\r\nAC\r\n>beta other text\nTTAA";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -800,7 +862,7 @@ test "reader-size matrix matches both formats across token boundaries" {
     }
 }
 
-test "header limit is exact across read fragments" {
+test "[property] - [index scanners]: enforce the header limit across read fragments" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -851,7 +913,7 @@ test "header limit is exact across read fragments" {
     }
 }
 
-test "indexing handles a sequence split at the production read boundary" {
+test "[edge] - [index scanners]: preserve sequence data split at the read boundary" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -882,7 +944,7 @@ test "indexing handles a sequence split at the production read boundary" {
     try std.testing.expectEqual(@as(u32, INDEX_READ_BUFFER_SIZE + 5), index.records.items[0].line_bytes);
 }
 
-test "FAI counts wrapped final short line with trailing newline correctly" {
+test "[edge] - [FAI scanner]: counts a wrapped short final line with newline" {
     const data = ">chrSynthetic\nAAAAAAAA\nCCCCCCCC\nGGGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -896,7 +958,7 @@ test "FAI counts wrapped final short line with trailing newline correctly" {
     try std.testing.expectEqualStrings("chrSynthetic\t20\t14\t8\t9\n", out.written());
 }
 
-test "indexing rejects sequence names longer than u16" {
+test "[failure] - [FASTA scanner]: rejects names above the u16 limit" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -916,7 +978,7 @@ test "indexing rejects sequence names longer than u16" {
     );
 }
 
-test "FAI uses the first base-bearing line after a blank" {
+test "[edge] - [index scanners]: use the first base-bearing line after a blank" {
     const data = ">seq\n\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -936,7 +998,7 @@ test "FAI uses the first base-bearing line after a blank" {
     try std.testing.expectEqual(@as(u32, 5), records.items[0].line_bytes);
 }
 
-test "FAI handles a short final line without terminal newline" {
+test "[edge] - [FAI scanner]: accepts a short final line without terminal newline" {
     const data = ">seq\nAAAA\nBB";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -948,7 +1010,7 @@ test "FAI handles a short final line without terminal newline" {
     try std.testing.expectEqualStrings("seq\t6\t5\t4\t5\n", output.written());
 }
 
-test "trailing space before LF is non-uniform and FAI rejects it" {
+test "[failure] - [index scanners]: reject trailing space as non-uniform FAI" {
     // `AAAA ` + LF looks like sep_len==2 by counts alone but is not CRLF.
     const data = ">s\nAAAA \n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -968,7 +1030,7 @@ test "trailing space before LF is non-uniform and FAI rejects it" {
     );
 }
 
-test "trailing tab before LF is non-uniform and FAI rejects it" {
+test "[failure] - [FAI scanner]: rejects a trailing tab as non-uniform" {
     const data = ">s\nAAAA\t\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -982,7 +1044,7 @@ test "trailing tab before LF is non-uniform and FAI rejects it" {
     );
 }
 
-test "LF body with final CRLF stays uniform and FAI accepts it" {
+test "[edge] - [index scanners]: accept final CRLF after a uniform LF body" {
     // Final CRLF is a terminator, not a wider wrap.
     const data = ">seq\nAAAA\nAAAA\r\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -1000,7 +1062,7 @@ test "LF body with final CRLF stays uniform and FAI accepts it" {
     try std.testing.expectEqualStrings("seq\t8\t5\t4\t5\n", fai.written());
 }
 
-test "mixed interior LF and CRLF is non-uniform and FAI rejects it" {
+test "[failure] - [index scanners]: reject mixed interior LF and CRLF as non-uniform FAI" {
     // Unlike a trailing CRLF, an interior CRLF breaks fixed-width stride.
     const data = ">seq\nAAAA\nAAAA\r\nAAAA\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -1019,7 +1081,7 @@ test "mixed interior LF and CRLF is non-uniform and FAI rejects it" {
     );
 }
 
-test "ZFI marks interior blank lines non-uniform" {
+test "[edge] - [ZFI scanner]: marks interior blank lines non-uniform" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1032,7 +1094,7 @@ test "ZFI marks interior blank lines non-uniform" {
     try std.testing.expect(!index.records.items[0].isUniformWidth());
 }
 
-test "FAI skips empty records" {
+test "[edge] - [FAI scanner]: skips empty records" {
     const data = ">empty\n>next\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1044,7 +1106,7 @@ test "FAI skips empty records" {
     try std.testing.expectEqualStrings("next\t4\t13\t4\t5\n", output.written());
 }
 
-test "empty sequence name: ZFI loads and looks up like samtools FAI" {
+test "[integration] - [index loaders]: resolve an empty sequence name" {
     // `>\nACGT\n`: samtools writes `.fai` with an empty name field (line starts with tab).
     const data = ">\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -1077,7 +1139,7 @@ test "empty sequence name: ZFI loads and looks up like samtools FAI" {
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName(""));
 }
 
-test "empty sequence name: first-wins when a later empty-name record appears" {
+test "[edge] - [index scanners]: keep the first empty sequence name" {
     const data = ">\nACGT\n>\nTTAA\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1094,7 +1156,7 @@ test "empty sequence name: first-wins when a later empty-name record appears" {
     try std.testing.expectEqual(@as(u64, 4), index.records.items[0].seq_len);
 }
 
-test "empty sequence name: FAI text loads and resolves empty lookup" {
+test "[integration] - [FAI loader]: resolves an empty sequence name" {
     const data = ">\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1123,7 +1185,7 @@ test "empty sequence name: FAI text loads and resolves empty lookup" {
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName(""));
 }
 
-test "FAI accepts long sequence names within the limit" {
+test "[edge] - [FAI scanner]: accepts long names within the limit" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1138,10 +1200,13 @@ test "FAI accepts long sequence names within the limit" {
     defer output.deinit();
     const count = try scanFaiData(fasta.items, &output.writer, true, allocator);
     try std.testing.expectEqual(@as(u32, 1), count);
-    try std.testing.expect(std.mem.startsWith(u8, output.written(), fasta.items[1..10_001]));
+    const suffix = "\t4\t10014\t4\t5\n";
+    try std.testing.expectEqual(@as(usize, 10_000 + suffix.len), output.written().len);
+    try std.testing.expectEqualSlices(u8, fasta.items[1..10_001], output.written()[0..10_000]);
+    try std.testing.expectEqualStrings(suffix, output.written()[10_000..]);
 }
 
-test "loadIndexChecked rejects corrupt zfi records" {
+test "[failure] - [ZFI loader]: rejects record names outside the name blob" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1163,7 +1228,7 @@ test "loadIndexChecked rejects corrupt zfi records" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked rejects seq_offset at end of file" {
+test "[failure] - [ZFI loader]: rejects a sequence offset at EOF" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1186,7 +1251,7 @@ test "loadIndexChecked rejects seq_offset at end of file" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked rejects zfi with zero record_count" {
+test "[failure] - [ZFI loader]: rejects a zero record count" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1202,7 +1267,7 @@ test "loadIndexChecked rejects zfi with zero record_count" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects truncated zfi header" {
+test "[failure] - [ZFI loader]: rejects a truncated header" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1214,7 +1279,7 @@ test "loadIndexChecked rejects truncated zfi header" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi record_count larger than file" {
+test "[failure] - [ZFI loader]: rejects a record count beyond the file" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1233,7 +1298,7 @@ test "loadIndexChecked rejects zfi record_count larger than file" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi with bad magic" {
+test "[failure] - [ZFI loader]: rejects invalid magic" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1252,7 +1317,7 @@ test "loadIndexChecked rejects zfi with bad magic" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi name blob overlapping records" {
+test "[failure] - [ZFI loader]: rejects a name blob overlapping records" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1275,7 +1340,7 @@ test "loadIndexChecked rejects zfi name blob overlapping records" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi side table offset into records" {
+test "[failure] - [ZFI loader]: rejects a side table offset inside records" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1298,7 +1363,7 @@ test "loadIndexChecked rejects zfi side table offset into records" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi side table with empty line_count" {
+test "[failure] - [ZFI loader]: rejects an empty side table" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1320,7 +1385,7 @@ test "loadIndexChecked rejects zfi side table with empty line_count" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects malformed zfi side table lines" {
+test "[failure] - [ZFI loader]: rejects malformed side-table lines" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1373,7 +1438,7 @@ test "loadIndexChecked rejects malformed zfi side table lines" {
     }
 }
 
-test "loadIndexChecked rejects overlapping zfi side tables" {
+test "[failure] - [ZFI loader]: rejects overlapping side tables" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1398,7 +1463,7 @@ test "loadIndexChecked rejects overlapping zfi side tables" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects mixed nameInZfi flags" {
+test "[failure] - [ZFI loader]: rejects mixed embedded-name flags" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1422,7 +1487,7 @@ test "loadIndexChecked rejects mixed nameInZfi flags" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects FASTA-backed zfi names" {
+test "[failure] - [ZFI loader]: rejects FASTA-backed names" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1443,7 +1508,7 @@ test "loadIndexChecked rejects FASTA-backed zfi names" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked accepts production zfi with side tables and name blob" {
+test "[integration] - [ZFI loader]: accepts side tables and an embedded name blob" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1466,7 +1531,7 @@ test "loadIndexChecked accepts production zfi with side tables and name blob" {
     try std.testing.expectEqualStrings("seq", idx.recordName(0).?);
 }
 
-test "index loaders release allocations on every out-of-memory path" {
+test "[failure] - [index loaders]: release partial allocations" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         loadAndDeinitForAllocationCheck,
@@ -1499,7 +1564,7 @@ test "index loaders release allocations on every out-of-memory path" {
     );
 }
 
-test "loadIndexCheckedWithMode selects first duplicate in zfi" {
+test "[property] - [ZFI loader]: modes select the first duplicate" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1528,7 +1593,7 @@ test "loadIndexCheckedWithMode selects first duplicate in zfi" {
     try std.testing.expectEqual(@as(?usize, 0), positional_idx.lookupName("dup"));
 }
 
-test "loadIndexChecked uses valid zfi and rejects it when stale despite valid fai" {
+test "[integration] - [index loader]: gives a present ZFI authority over FAI" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1570,7 +1635,7 @@ test "loadIndexChecked uses valid zfi and rejects it when stale despite valid fa
     try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked rejects invalid present zfi despite valid fai" {
+test "[failure] - [index loader]: rejects an invalid present ZFI despite valid FAI" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1609,7 +1674,7 @@ test "loadIndexChecked rejects invalid present zfi despite valid fai" {
     }
 }
 
-test "loadIndexChecked reports an inaccessible selected sidecar" {
+test "[failure] - [index loader]: reports an inaccessible selected sidecar" {
     if (comptime builtin.os.tag == .windows or builtin.os.tag == .wasi) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -1660,7 +1725,7 @@ test "loadIndexChecked reports an inaccessible selected sidecar" {
     }
 }
 
-test "loadIndexCheckedWithMode selects first duplicate in fai" {
+test "[property] - [FAI loader]: modes select the first duplicate" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1693,7 +1758,7 @@ test "loadIndexCheckedWithMode selects first duplicate in fai" {
     try std.testing.expectEqual(@as(?usize, 0), positional_idx.lookupName("dup"));
 }
 
-test "positional fai loading retains first matches and validates the complete sidecar" {
+test "[integration] - [FAI loader]: positional mode retains first matches and validates all records" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1765,7 +1830,7 @@ test "positional fai loading retains first matches and validates the complete si
     );
 }
 
-test "full fai lookup borrows mapped names" {
+test "[unit] - [FAI loader]: full lookup borrows mapped names" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1797,7 +1862,7 @@ test "full fai lookup borrows mapped names" {
     try std.testing.expectEqual(mapped_name.ptr, map_entry.key_ptr.*.ptr);
 }
 
-test "loadIndexChecked retains FASTA descriptor for fai positional reads" {
+test "[integration] - [FAI loader]: positional mode retains the FASTA descriptor" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1830,7 +1895,7 @@ test "loadIndexChecked retains FASTA descriptor for fai positional reads" {
     try std.testing.expectEqual(@as(u8, '>'), first_byte[0]);
 }
 
-test "GET loader keeps FASTA readable without mapping it" {
+test "[integration] - [get index loader]: keeps FASTA readable without mapping it" {
     var zfi_idx = main.index_format.loadIndexForGet(std.testing.allocator, io, "tests/data/simple.fasta", .lookup_full_map);
     defer zfi_idx.deinit();
 
@@ -1869,7 +1934,7 @@ test "GET loader keeps FASTA readable without mapping it" {
     try std.testing.expectEqual(@as(u8, '>'), first_byte[0]);
 }
 
-test "stats loader keeps zfi FASTA readable without mapping it" {
+test "[integration] - [stats index loader]: keeps ZFI FASTA readable without mapping it" {
     var idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, "tests/data/simple.fasta", .stats_scan);
     defer idx.deinit();
 
@@ -1885,92 +1950,75 @@ test "stats loader keeps zfi FASTA readable without mapping it" {
     try std.testing.expectEqual(@as(u8, '>'), first_byte[0]);
 }
 
-test "loadIndexChecked rejects fai with zero line_bases" {
+test "[failure] - [FAI loader]: rejects malformed numeric fields and impossible geometry" {
+    const Case = struct {
+        stem: []const u8,
+        fai: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .stem = "bad-fai-zero-length", .fai = "seq1\t0\t6\t4\t5\n" },
+        .{ .stem = "bad-fai-zero-bases", .fai = "seq1\t4\t6\t0\t5\n" },
+        .{ .stem = "bad-fai-zero-bytes", .fai = "seq1\t4\t6\t4\t0\n" },
+        .{ .stem = "bad-fai-line-bytes", .fai = "seq1\t4\t6\t5\t4\n" },
+        .{ .stem = "bad-fai-offset", .fai = "seq1\t4\t11\t4\t5\n" },
+        .{ .stem = "bad-fai-span", .fai = "seq1\t100\t6\t4\t5\n" },
+        .{ .stem = "bad-fai-max-length", .fai = "seq1\t18446744073709551615\t6\t4\t5\n" },
+        .{ .stem = "bad-fai-u64-overflow", .fai = "seq1\t99999999999999999999\t6\t4\t5\n" },
+        .{ .stem = "bad-fai-u32-overflow", .fai = "seq1\t4\t6\t4294967296\t5\n" },
+    };
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-zero-bases", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t0\t5\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
+    for (cases) |case| {
+        const paths = try writeFastaAndFai(allocator, case.stem, ">seq1\nACGT\n", case.fai);
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+        try std.testing.expectError(
+            error.CorruptIndex,
+            loadIndexChecked(std.testing.allocator, io, paths.fasta_path),
+        );
+    }
 }
 
-test "loadIndexChecked rejects fai with line_bytes less than line_bases" {
+test "[property] - [FAI loaders]: reject malformed fields in every mode" {
+    const Case = struct {
+        stem: []const u8,
+        fai: []const u8,
+    };
+    const cases = [_]Case{
+        .{ .stem = "empty-fai", .fai = "" },
+        .{ .stem = "blank-fai", .fai = "\n\n" },
+        .{ .stem = "missing-fields", .fai = "seq1\t4\t6\t4\n" },
+        .{ .stem = "empty-field", .fai = "seq1\t\t6\t4\t5\n" },
+        .{ .stem = "non-decimal-field", .fai = "seq1\t4x\t6\t4\t5\n" },
+        .{ .stem = "signed-field", .fai = "seq1\t-4\t6\t4\t5\n" },
+    };
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-line-bytes", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+    for (cases) |case| {
+        const paths = try writeFastaAndFai(allocator, case.stem, ">seq1\nACGT\n", case.fai);
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
 
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t5\t4\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
+        try std.testing.expectError(
+            error.CorruptIndex,
+            main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, paths.fasta_path, .lookup_full_map),
+        );
+        try std.testing.expectError(
+            error.CorruptIndex,
+            main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, paths.fasta_path, .{ .positional = &.{"seq1"} }),
+        );
+        try std.testing.expectError(
+            error.CorruptIndex,
+            main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, paths.fasta_path, .stats_scan),
+        );
+    }
 }
 
-test "loadIndexChecked rejects fai with seq_offset past EOF" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-offset", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t99\t4\t5\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
-}
-
-test "loadIndexChecked rejects fai whose sequence span exceeds FASTA" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-span", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    // seq_len 100 from offset 6 cannot fit in an 11-byte FASTA.
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t100\t6\t4\t5\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
-}
-
-test "loadIndexCheckedWithMode positional rejects impossible fai geometry" {
+test "[failure] - [FAI loader]: positional mode rejects impossible geometry" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -1994,7 +2042,7 @@ test "loadIndexCheckedWithMode positional rejects impossible fai geometry" {
     );
 }
 
-test "stats loader rejects impossible fai geometry" {
+test "[failure] - [FAI loader]: stats mode rejects impossible geometry" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2018,50 +2066,7 @@ test "stats loader rejects impossible fai geometry" {
     );
 }
 
-test "loadIndexChecked rejects fai decimal overflow in seq_len" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-u64-overflow", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    // 20 nines overflows u64 during decimal accumulation (max u64 is 20 digits starting with 1).
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t99999999999999999999\t6\t4\t5\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
-}
-
-test "loadIndexChecked rejects fai line_bases above u32" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-u32-overflow", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t4294967296\t5\n");
-
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
-}
-
-test "loadIndexChecked rejects fai name longer than u16" {
+test "[failure] - [FAI loader]: rejects names above the u16 limit" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2087,7 +2092,7 @@ test "loadIndexChecked rejects fai name longer than u16" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "streamed fai loading accepts the maximum sequence name" {
+test "[edge] - [FAI loader]: streamed modes accept the maximum sequence name" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2135,72 +2140,42 @@ test "streamed fai loading accepts the maximum sequence name" {
     }
 }
 
-test "fai loaders agree when index omits terminal newline" {
+test "[property] - [FAI loaders]: agree when FASTA or index omits the terminal newline" {
+    const Case = struct {
+        stem: []const u8,
+        fasta: []const u8,
+        fai: []const u8,
+    };
+    const cases = [_]Case{
+        .{
+            .stem = "fai-no-term-nl",
+            .fasta = ">s1\nACGT\n>s2\nGGGGGG\n>s3\nCCCCC\n",
+            .fai = "s1\t4\t4\t4\t5\ns2\t6\t13\t6\t7\ns3\t5\t24\t5\t6",
+        },
+        .{
+            .stem = "fasta-no-term-nl",
+            .fasta = ">seq1\nACGT",
+            .fai = "seq1\t4\t6\t4\t5\n",
+        },
+        .{
+            .stem = "both-no-term-nl",
+            .fasta = ">seq1\nAAAA\nBBBB",
+            .fai = "seq1\t8\t6\t4\t5",
+        },
+    };
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "fai-no-term-nl", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">s1\nACGT\n>s2\nGGGGGG\n>s3\nCCCCC\n");
-
-    // Three records with distinct extrema; final `.fai` line has no trailing `\n`.
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "s1\t4\t4\t4\t5\ns2\t6\t13\t6\t7\ns3\t5\t24\t5\t6");
-
-    try expectFaiLoaderModesAgree(allocator, fasta_path);
+    for (cases) |case| {
+        const paths = try writeFastaAndFai(allocator, case.stem, case.fasta, case.fai);
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+        try expectFaiLoaderModesAgree(allocator, paths.fasta_path);
+    }
 }
 
-test "fai loaders agree when FASTA omits terminal newline" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "fasta-no-term-nl", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    // Samtools-style line_bytes still counts the separator even when the final line has none.
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t4\t5\n");
-
-    try expectFaiLoaderModesAgree(allocator, fasta_path);
-}
-
-test "fai loaders agree when FASTA and index both omit terminal newline" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-
-    const fasta_path = try uniqueArtifactPath(allocator, "both-no-term-nl", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nAAAA\nBBBB");
-
-    const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-    defer fai_file.close(io);
-    try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t8\t6\t4\t5");
-
-    try expectFaiLoaderModesAgree(allocator, fasta_path);
-}
-
-test "loadIndexChecked accepts zfi when FASTA omits terminal newline" {
+test "[edge] - [ZFI loader]: accepts FASTA without a terminal newline" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2225,7 +2200,7 @@ test "loadIndexChecked accepts zfi when FASTA omits terminal newline" {
     try std.testing.expectEqual(@as(u64, 4), idx.records[0].seq_len);
 }
 
-test "emit-fai rejects non-uniform sequence layout" {
+test "[failure] - [FAI scanner]: rejects non-uniform sequence layout without output" {
     const data =
         \\>mixed
         \\AAAA
@@ -2246,7 +2221,7 @@ test "emit-fai rejects non-uniform sequence layout" {
     try std.testing.expectEqual(@as(usize, 0), out.written().len);
 }
 
-test "FAI uses a separate spool and cleans it after success" {
+test "[integration] - [FAI workflow]: uses a separate spool and cleans it after success" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2312,8 +2287,7 @@ test "FAI uses a separate spool and cleans it after success" {
         },
         else => return error.ChildProcessFailed,
     }
-    try std.testing.expectEqual(expected.written().len, result.stdout.len);
-    try std.testing.expectEqual(null, std.mem.findDiff(u8, expected.written(), result.stdout));
+    try std.testing.expectEqualSlices(u8, expected.written(), result.stdout);
     try std.testing.expect(result.stdout.len > (try std.Io.Dir.cwd().statFile(io, fasta_path, .{})).size);
     try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
     try expectDirectoryEmpty(spool_dir_path);
@@ -2323,7 +2297,7 @@ test "FAI uses a separate spool and cleans it after success" {
     try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, sibling, .{}));
 }
 
-test "FAI failure leaves stdout and spool empty" {
+test "[failure] - [FAI workflow]: leaves output and spool empty" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2367,7 +2341,7 @@ test "FAI failure leaves stdout and spool empty" {
     try expectDirectoryEmpty(spool_dir_path);
 }
 
-test "loadIndexChecked rejects zfi after FASTA size change" {
+test "[failure] - [ZFI loader]: rejects a source size change" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2396,7 +2370,7 @@ test "loadIndexChecked rejects zfi after FASTA size change" {
     try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked rejects zfi after same-size FASTA replacement" {
+test "[failure] - [ZFI loader]: rejects a same-size source replacement" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2435,7 +2409,7 @@ test "loadIndexChecked rejects zfi after same-size FASTA replacement" {
     try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
+test "[integration] - [ZFI loader]: accepts a legacy index without source identity" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2470,7 +2444,7 @@ test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
 }
 
-test "loadIndexChecked accepts embedded names with legacy 16-byte footer" {
+test "[integration] - [ZFI loader]: accepts embedded names with the legacy footer" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2505,7 +2479,7 @@ test "loadIndexChecked accepts embedded names with legacy 16-byte footer" {
     try std.testing.expectEqualStrings("seq1", idx.recordName(0).?);
 }
 
-test "loadIndexChecked rejects zfi with wrong embedded source mtime" {
+test "[failure] - [ZFI loader]: rejects mismatched embedded source time" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2538,7 +2512,7 @@ test "loadIndexChecked rejects zfi with wrong embedded source mtime" {
     try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "loadIndexChecked rejects truncated zfi mid-record" {
+test "[failure] - [ZFI loader]: rejects truncation inside a record" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2555,7 +2529,7 @@ test "loadIndexChecked rejects truncated zfi mid-record" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
-test "loadIndexChecked rejects zfi with zero line geometry" {
+test "[failure] - [ZFI loader]: rejects zero line geometry" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2578,7 +2552,7 @@ test "loadIndexChecked rejects zfi with zero line geometry" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "reader keeps trailing-blank record uniform" {
+test "[edge] - [ZFI scanner]: keeps a trailing-blank record uniform" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2590,7 +2564,7 @@ test "reader keeps trailing-blank record uniform" {
     try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
 }
 
-test "reader ignores a trailing blank before the next header" {
+test "[edge] - [index scanners]: ignore a trailing blank before the next header" {
     const data = ">a\nAAAA\n\n>b\nCCCC\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2613,7 +2587,7 @@ test "reader ignores a trailing blank before the next header" {
     try std.testing.expectEqualStrings("a\t4\t3\t4\t5\nb\t4\t12\t4\t5\n", fai.written());
 }
 
-test "reader marks interior blank non-uniform" {
+test "[edge] - [ZFI scanner]: marks an interior blank non-uniform" {
     const data = ">seq\nAAAA\n\nCCCC\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2624,7 +2598,7 @@ test "reader marks interior blank non-uniform" {
     try std.testing.expect(!index.records.items[0].isUniformWidth());
 }
 
-test "reader marks an interior blank after a uniform stride prefix non-uniform" {
+test "[edge] - [index scanners]: reject an interior blank after a uniform stride prefix" {
     const data = ">seq\nAAAA\nAAAA\nAAAA\n\nAAAA\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2648,7 +2622,7 @@ test "reader marks an interior blank after a uniform stride prefix non-uniform" 
     );
 }
 
-test "reader keeps a short final line uniform without a side table" {
+test "[edge] - [ZFI scanner]: keeps many full lines and a short final line uniform" {
     // Many full-width lines plus a short last wrap remain formula-uniform without
     // materializing O(lines) side-table rows.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -2675,7 +2649,7 @@ test "reader keeps a short final line uniform without a side table" {
     try std.testing.expectEqual(@as(u64, 4000 * 60 + 4), index.records.items[0].seq_len);
 }
 
-test "interior short line creates a side table" {
+test "[edge] - [ZFI scanner]: creates a side table for an interior short line" {
     const data = ">seq\nAAAA\nAAAA\nAA\nAAAA\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2687,7 +2661,7 @@ test "interior short line creates a side table" {
     try std.testing.expect(index.side_tables.items.len > 0);
 }
 
-test "long final line is non-uniform" {
+test "[edge] - [ZFI scanner]: marks a long final line non-uniform" {
     const data = ">seq\nAAAA\nAAAA\nAAAAAA\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2699,7 +2673,7 @@ test "long final line is non-uniform" {
     try std.testing.expect(index.side_tables.items.len > 0);
 }
 
-test "short final line without terminal newline stays uniform" {
+test "[edge] - [ZFI scanner]: keeps a short final line without newline uniform" {
     const data = ">seq\nAAAA\nAAAA\nAC";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2711,7 +2685,7 @@ test "short final line without terminal newline stays uniform" {
     try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
 }
 
-test "short final line across read boundary stays uniform" {
+test "[edge] - [ZFI scanner]: keeps a short final line across the read boundary uniform" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2731,7 +2705,7 @@ test "short final line across read boundary stays uniform" {
     try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
 }
 
-test "CRLF uniform body with short final stays uniform" {
+test "[edge] - [ZFI scanner]: keeps a CRLF body with a short final line uniform" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2756,7 +2730,7 @@ test "CRLF uniform body with short final stays uniform" {
     try std.testing.expectEqual(@as(u32, 62), index.records.items[0].line_bytes);
 }
 
-test "stride blocks fall back at validation boundaries" {
+test "[property] - [index scanners]: stride blocks fall back at validation boundaries" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2786,7 +2760,7 @@ test "stride blocks fall back at validation boundaries" {
     }
 }
 
-test "CRLF stride blocks match both formats" {
+test "[property] - [index scanners]: CRLF stride blocks preserve both formats" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2812,7 +2786,7 @@ test "CRLF stride blocks match both formats" {
     }
 }
 
-test "multi-record uniform bodies stay uniform" {
+test "[property] - [ZFI scanner]: keeps multiple uniform bodies uniform" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -2840,7 +2814,7 @@ test "multi-record uniform bodies stay uniform" {
     }
 }
 
-test "short final plus next header spanning stride width preserves the next record" {
+test "[regression] - [ZFI scanner]: preserves a header spanning the prior stride width" {
     // Genome chr10→chr11: `NN\\n` + `>11 ... REF\\n` is exactly line_bytes (61). Stride must
     // not treat that span as one wrap or the next record is swallowed into the previous.
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -2875,7 +2849,7 @@ test "short final plus next header spanning stride width preserves the next reco
 
 // --- Stable gates fixtures ---
 
-test "gates fixture: duplicate names keep first occurrence" {
+test "[integration] - [index gates]: duplicate names keep the first occurrence" {
     try requireFixturePath("tests/data/gates/duplicates.fasta");
     const data = try readTestFile(std.testing.allocator, "tests/data/gates/duplicates.fasta");
     defer std.testing.allocator.free(data);
@@ -2897,7 +2871,7 @@ test "gates fixture: duplicate names keep first occurrence" {
     try std.testing.expectEqual(@as(u64, 4), index.records.items[1].seq_len);
 }
 
-test "gates fixture: long header indexes and over-u16 name rejects" {
+test "[integration] - [index gates]: enforce the header length boundary" {
     try requireFixturePath("tests/data/gates/long_header.fasta");
     try requireFixturePath("tests/data/gates/long_header_reject.fasta");
 
@@ -2914,14 +2888,14 @@ test "gates fixture: long header indexes and over-u16 name rejects" {
 
     const reject_data = try readTestFile(allocator, "tests/data/gates/long_header_reject.fasta");
     defer allocator.free(reject_data);
-    try std.testing.expect(reject_data[0] == '>');
+    try std.testing.expectEqual(@as(u8, '>'), reject_data[0]);
     // Fixture must stay LF-only; a Windows CRLF checkout makes indexOf('\\n')-1 count the '\\r'.
-    try std.testing.expect(std.mem.findScalar(u8, reject_data, '\r') == null);
+    try std.testing.expectEqual(null, std.mem.findScalar(u8, reject_data, '\r'));
     try std.testing.expectEqual(main.indexer.MAX_INDEX_NAME_LEN + 1, std.mem.findScalar(u8, reject_data, '\n').? - 1);
     try std.testing.expectError(error.HeaderTooLong, main.indexer.scanZfiData(reject_data, true, allocator));
 }
 
-test "gates fixture: invalid UTF-8 header bytes index and stay embeddable" {
+test "[integration] - [index gates]: preserve invalid UTF-8 header bytes" {
     try requireFixturePath("tests/data/gates/invalid_utf8_header.fasta");
     const data = try readTestFile(std.testing.allocator, "tests/data/gates/invalid_utf8_header.fasta");
     defer std.testing.allocator.free(data);
@@ -2938,7 +2912,7 @@ test "gates fixture: invalid UTF-8 header bytes index and stay embeddable" {
     try std.testing.expectEqualSlices(u8, "bad\xffname", name0);
 }
 
-test "gates fixture: zero geometry and large offset FAI rejected" {
+test "[integration] - [index gates]: reject invalid FAI geometry fixtures" {
     try requireFixturePath("tests/data/gates/seq1_zero_geometry.fasta");
     try requireFixturePath("tests/data/gates/seq1_zero_geometry.fasta.fai");
     try requireFixturePath("tests/data/gates/seq1_large_offset.fasta");
@@ -2953,7 +2927,7 @@ test "gates fixture: zero geometry and large offset FAI rejected" {
     try expectCorruptFaiFixture(allocator, "tests/data/gates/seq1_large_offset");
 }
 
-test "gates fixture: zfi zero geometry from stable seq1 FASTA rejected" {
+test "[integration] - [index gates]: reject zero ZFI geometry" {
     try requireFixturePath("tests/data/gates/seq1_zero_geometry.fasta");
     const fasta_data = try readTestFile(std.testing.allocator, "tests/data/gates/seq1_zero_geometry.fasta");
     defer std.testing.allocator.free(fasta_data);

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -10,12 +10,20 @@ const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" e
 const validateFasta = main.validateFasta;
 const scanFaiData = main.indexer.scanFaiData;
 const index_read_buffer_size = main.indexer.index_read_buffer_size;
-const loadIndexChecked = main.index_format.loadIndexChecked;
 const IndexRecord = main.IndexRecord;
 const ZfiHeader = main.ZfiHeader;
 const ZFI_MAGIC = main.ZFI_MAGIC;
 const c = std.c;
 const io = std.testing.io;
+
+fn loadIndexChecked(test_io: std.Io, fasta_path: []const u8) main.index_format.LoadIndexError!main.index_format.LoadedIndex {
+    return main.index_format.loadIndexChecked(std.testing.allocator, test_io, fasta_path);
+}
+
+fn loadAndDeinitForAllocationCheck(allocator: std.mem.Allocator, fasta_path: []const u8, mode: main.index_format.LoadMode) !void {
+    var idx = try main.index_format.loadIndexCheckedWithMode(allocator, io, fasta_path, mode);
+    defer idx.deinit();
+}
 
 fn statMtimeNs(path: []const u8) !u64 {
     const file = try std.Io.Dir.cwd().openFile(io, path, .{});
@@ -40,8 +48,8 @@ fn writeFastaAndRawZfi(allocator: std.mem.Allocator, stem: []const u8, fasta: []
 
     var zfi_copy = try allocator.dupe(u8, zfi_bytes);
     defer allocator.free(zfi_copy);
-    const footer_len = main.index_format.zfi_name_footer_bytes;
-    const id_len = main.index_format.zfi_source_id_bytes;
+    const footer_len = main.index_format.ZFI_NAME_FOOTER_BYTES;
+    const id_len = main.index_format.ZFI_SOURCE_ID_BYTES;
     // Production layout: `[name blob][ZFID][ZFNM footer]`.
     if (zfi_copy.len >= footer_len + id_len) {
         const id_off = zfi_copy.len - footer_len - id_len;
@@ -555,7 +563,7 @@ test "writeZfiIndexFile creates valid production layout" {
     try std.testing.expect(index.records.items[0].nameInZfi());
     try std.testing.expectEqualStrings("seq", index.name_blob.items);
     try std.testing.expectEqual(
-        @as(u64, 16 + 40 + index.name_blob.items.len + main.index_format.zfi_name_footer_bytes + main.index_format.zfi_source_id_bytes),
+        @as(u64, 16 + 40 + index.name_blob.items.len + main.index_format.ZFI_NAME_FOOTER_BYTES + main.index_format.ZFI_SOURCE_ID_BYTES),
         stat.size,
     );
 }
@@ -678,7 +686,7 @@ test "scanZfiReader zfi loads record names" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
     var idx = try loadIndexChecked(io, paths.fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName("seq1"));
     try std.testing.expectEqual(@as(?usize, 1), idx.lookupName("seq2"));
 }
@@ -1057,9 +1065,9 @@ test "empty sequence name: ZFI loads and looks up like samtools FAI" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
     var idx = try loadIndexChecked(io, paths.fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(@as(usize, 1), idx.records.len);
-    try std.testing.expectEqualStrings("", idx.getRecordName(0));
+    try std.testing.expectEqualStrings("", idx.recordName(0).?);
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName(""));
 }
 
@@ -1103,9 +1111,9 @@ test "empty sequence name: FAI text loads and resolves empty lookup" {
     }
 
     var idx = try loadIndexChecked(io, fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(@as(usize, 1), idx.records.len);
-    try std.testing.expectEqualStrings("", idx.getRecordName(0));
+    try std.testing.expectEqualStrings("", idx.recordName(0).?);
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName(""));
 }
 
@@ -1314,6 +1322,84 @@ test "loadIndexChecked rejects zfi side table with empty line_count" {
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
 }
 
+test "loadIndexChecked rejects malformed zfi side table lines" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const fasta_data = ">seq\nAAA\nCCCC\nGG\n";
+    var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
+    defer index.deinit(allocator);
+    const table_offset: usize = @intCast(index.records.items[0].sideTableOffset());
+
+    const Mutation = enum {
+        broken_base_prefix,
+        repeated_byte_offset,
+        line_past_fasta,
+        wrong_base_total,
+    };
+    const cases = [_]Mutation{
+        .broken_base_prefix,
+        .repeated_byte_offset,
+        .line_past_fasta,
+        .wrong_base_total,
+    };
+
+    for (cases) |case| {
+        const zfi_bytes = try main.indexer.zfiIndexToBytes(&index, fasta_data.len, 0, allocator);
+        defer allocator.free(zfi_bytes);
+        const line_count = std.mem.readInt(u64, zfi_bytes[table_offset..][0..8], .little);
+        try std.testing.expect(line_count >= 2);
+        const first_line = table_offset + @sizeOf(u64);
+        const second_line = first_line + @sizeOf(main.index_format.SideTableLine);
+        const last_line = first_line + (@as(usize, @intCast(line_count)) - 1) * @sizeOf(main.index_format.SideTableLine);
+
+        switch (case) {
+            .broken_base_prefix => std.mem.writeInt(u64, zfi_bytes[first_line..][0..8], 1, .little),
+            .repeated_byte_offset => {
+                const first_offset = std.mem.readInt(u64, zfi_bytes[first_line + 8 ..][0..8], .little);
+                std.mem.writeInt(u64, zfi_bytes[second_line + 8 ..][0..8], first_offset, .little);
+            },
+            .line_past_fasta => std.mem.writeInt(u64, zfi_bytes[first_line + 16 ..][0..8], fasta_data.len + 1, .little),
+            .wrong_base_total => {
+                const line_bases = std.mem.readInt(u64, zfi_bytes[last_line + 24 ..][0..8], .little);
+                std.mem.writeInt(u64, zfi_bytes[last_line + 24 ..][0..8], line_bases + 1, .little);
+            },
+        }
+
+        const paths = try writeFastaAndRawZfi(allocator, @tagName(case), fasta_data, zfi_bytes);
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
+
+        try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    }
+}
+
+test "loadIndexChecked rejects overlapping zfi side tables" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const fasta_data = ">a\nAAA\nCCCC\nGG\n>b\nTT\nAAAA\nC\n";
+    var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
+    defer index.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 2), index.records.items.len);
+    try std.testing.expect(!index.records.items[0].isUniformWidth());
+    try std.testing.expect(!index.records.items[1].isUniformWidth());
+
+    index.records.items[1].seq_offset = index.records.items[0].seq_offset;
+    index.records.items[1].seq_len = index.records.items[0].seq_len;
+    try index.records.items[1].markNonUniform(index.records.items[0].sideTableOffset());
+
+    const zfi_bytes = try main.indexer.zfiIndexToBytes(&index, fasta_data.len, 0, allocator);
+    defer allocator.free(zfi_bytes);
+    const paths = try writeFastaAndRawZfi(allocator, "zfi-side-overlap", fasta_data, zfi_bytes);
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
+
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+}
+
 test "loadIndexChecked rejects mixed nameInZfi flags" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1346,7 +1432,7 @@ test "loadIndexChecked rejects FASTA-backed zfi names" {
     const fasta_data = ">seq\nACGT\n";
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
-    index.records.items[0]._pad[0] &= ~main.index_format.name_in_zfi_flag;
+    index.records.items[0]._pad[0] &= ~main.index_format.NAME_IN_ZFI_FLAG;
     index.records.items[0].name_offset = 1;
     index.name_blob.clearRetainingCapacity();
     const zfi_bytes = try main.indexer.zfiIndexToBytes(&index, fasta_data.len, 0, allocator);
@@ -1375,11 +1461,44 @@ test "loadIndexChecked accepts production zfi with side tables and name blob" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
     var idx = try loadIndexChecked(io, paths.fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     try std.testing.expect(idx.name_blob != null);
     try std.testing.expectEqual(@as(usize, 1), idx.records.len);
-    try std.testing.expectEqualStrings("seq", idx.getRecordName(0));
+    try std.testing.expectEqualStrings("seq", idx.recordName(0).?);
+}
+
+test "index loaders release allocations on every out-of-memory path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        loadAndDeinitForAllocationCheck,
+        .{ "tests/data/simple.fasta", main.index_format.LoadMode.lookup_full_map },
+    );
+
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const fasta_path = try uniqueArtifactPath(allocator, "fai-allocation-failures", "fa");
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, ">a\nAAAA\n>b\nCC\n");
+    }
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
+        defer fai_file.close(io);
+        try std.Io.File.writeStreamingAll(fai_file, io, "a\t4\t3\t4\t5\nb\t2\t11\t2\t3\n");
+    }
+
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        loadAndDeinitForAllocationCheck,
+        .{ fasta_path, main.index_format.LoadMode.stats_scan },
+    );
 }
 
 test "loadIndexCheckedWithMode selects first duplicate in zfi" {
@@ -1401,11 +1520,11 @@ test "loadIndexCheckedWithMode selects first duplicate in zfi" {
     defer index.deinit(allocator);
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
 
-    var full_map_idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .lookup_full_map);
-    defer full_map_idx.deinit(io);
+    var full_map_idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .lookup_full_map);
+    defer full_map_idx.deinit();
     const requested = [_][]const u8{"dup"};
-    var positional_idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .{ .positional = &requested });
-    defer positional_idx.deinit(io);
+    var positional_idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = &requested });
+    defer positional_idx.deinit();
 
     try std.testing.expectEqual(full_map_idx.lookupName("dup"), positional_idx.lookupName("dup"));
     try std.testing.expectEqual(@as(?usize, 0), positional_idx.lookupName("dup"));
@@ -1442,7 +1561,7 @@ test "loadIndexChecked uses valid zfi and rejects it when stale despite valid fa
 
     {
         var idx = try loadIndexChecked(io, fasta_path);
-        defer idx.deinit(io);
+        defer idx.deinit();
         try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     }
 
@@ -1562,16 +1681,16 @@ test "loadIndexCheckedWithMode selects first duplicate in fai" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "dup\t4\t5\t4\t5\ndup\t6\t15\t6\t7\n");
 
-    var full_map_idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .lookup_full_map);
-    defer full_map_idx.deinit(io);
+    var full_map_idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .lookup_full_map);
+    defer full_map_idx.deinit();
     const requested = [_][]const u8{"dup"};
-    var positional_idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .{ .positional = &requested });
-    defer positional_idx.deinit(io);
+    var positional_idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = &requested });
+    defer positional_idx.deinit();
 
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, positional_idx.source);
-    try std.testing.expect(positional_idx.has_name_map);
+    try std.testing.expect(positional_idx.name_map != null);
     try std.testing.expectEqual(@as(usize, 1), positional_idx.records.len);
-    try std.testing.expectEqualStrings("dup", positional_idx.getRecordName(0));
+    try std.testing.expectEqualStrings("dup", positional_idx.recordName(0).?);
     try std.testing.expectEqual(full_map_idx.lookupName("dup"), positional_idx.lookupName("dup"));
     try std.testing.expectEqual(@as(?usize, 0), positional_idx.lookupName("dup"));
 }
@@ -1608,14 +1727,15 @@ test "positional fai loading retains first matches and validates the complete si
     const requested = [_][]const u8{ "wanted", "missing", "colon:name", "" };
     {
         var idx = try main.index_format.loadIndexCheckedWithMode(
+            std.testing.allocator,
             io,
             fasta_path,
             .{ .positional = requested[0..] },
         );
-        defer idx.deinit(io);
+        defer idx.deinit();
 
         try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, idx.source);
-        try std.testing.expect(idx.has_name_map);
+        try std.testing.expect(idx.name_map != null);
         try std.testing.expectEqual(@as(usize, 3), idx.records.len);
         try std.testing.expectEqual(@as(usize, 3), idx.name_slices.len);
         try std.testing.expectEqual(@as(?usize, 0), idx.lookupName("wanted"));
@@ -1623,7 +1743,7 @@ test "positional fai loading retains first matches and validates the complete si
         try std.testing.expectEqual(@as(?usize, 2), idx.lookupName(""));
         try std.testing.expectEqual(@as(?usize, null), idx.lookupName("missing"));
         try std.testing.expectEqual(@as(u64, 4), idx.records[0].seq_len);
-        try std.testing.expectEqualStrings("wanted", idx.getRecordName(0));
+        try std.testing.expectEqualStrings("wanted", idx.recordName(0).?);
     }
 
     {
@@ -1639,6 +1759,7 @@ test "positional fai loading retains first matches and validates the complete si
     try std.testing.expectError(
         error.CorruptIndex,
         main.index_format.loadIndexCheckedWithMode(
+            std.testing.allocator,
             io,
             fasta_path,
             .{ .positional = requested[0..] },
@@ -1667,14 +1788,14 @@ test "full fai lookup borrows mapped names" {
         try std.Io.File.writeStreamingAll(fai_file, io, "seq\t4\t5\t4\t5\n");
     }
 
-    var idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .lookup_full_map);
-    defer idx.deinit(io);
+    var idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .lookup_full_map);
+    defer idx.deinit();
     const mapped_name = idx.records[0].getName(idx.fai_data.?);
-    var names = idx.name_map.iterator();
+    var names = idx.name_map.?.iterator();
     const map_entry = names.next().?;
 
     try std.testing.expectEqual(@as(usize, 0), idx.name_slices.len);
-    try std.testing.expectEqual(mapped_name.ptr, idx.getRecordName(0).ptr);
+    try std.testing.expectEqual(mapped_name.ptr, idx.recordName(0).?.ptr);
     try std.testing.expectEqual(mapped_name.ptr, map_entry.key_ptr.*.ptr);
 }
 
@@ -1700,8 +1821,8 @@ test "loadIndexChecked retains FASTA descriptor for fai positional reads" {
     }
 
     const requested = [_][]const u8{"seq"};
-    var idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .{ .positional = &requested });
-    defer idx.deinit(io);
+    var idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = &requested });
+    defer idx.deinit();
 
     var first_byte: [1]u8 = undefined;
     try std.testing.expectEqual(
@@ -1712,12 +1833,10 @@ test "loadIndexChecked retains FASTA descriptor for fai positional reads" {
 }
 
 test "GET loader keeps FASTA readable without mapping it" {
-    var zfi_idx = main.index_format.loadIndexForGet(io, "tests/data/simple.fasta", .lookup_full_map);
-    defer zfi_idx.deinit(io);
+    var zfi_idx = main.index_format.loadIndexForGet(std.testing.allocator, io, "tests/data/simple.fasta", .lookup_full_map);
+    defer zfi_idx.deinit();
 
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, zfi_idx.source);
-    try std.testing.expectEqual(null, zfi_idx.fasta_map);
-    try std.testing.expectEqual(@as(usize, 0), zfi_idx.fasta_data.len);
 
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -1739,12 +1858,10 @@ test "GET loader keeps FASTA readable without mapping it" {
         try std.Io.File.writeStreamingAll(fai_file, io, "seq\t4\t5\t4\t5\n");
     }
 
-    var fai_idx = main.index_format.loadIndexForGet(io, fasta_path, .lookup_full_map);
-    defer fai_idx.deinit(io);
+    var fai_idx = main.index_format.loadIndexForGet(std.testing.allocator, io, fasta_path, .lookup_full_map);
+    defer fai_idx.deinit();
 
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, fai_idx.source);
-    try std.testing.expectEqual(null, fai_idx.fasta_map);
-    try std.testing.expectEqual(@as(usize, 0), fai_idx.fasta_data.len);
 
     var first_byte: [1]u8 = undefined;
     try std.testing.expectEqual(
@@ -1755,14 +1872,12 @@ test "GET loader keeps FASTA readable without mapping it" {
 }
 
 test "stats loader keeps zfi FASTA readable without mapping it" {
-    var idx = try main.index_format.loadIndexCheckedWithMode(io, "tests/data/simple.fasta", .stats_scan);
-    defer idx.deinit(io);
+    var idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, "tests/data/simple.fasta", .stats_scan);
+    defer idx.deinit();
 
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
-    try std.testing.expectEqual(null, idx.fasta_map);
-    try std.testing.expectEqual(@as(usize, 0), idx.fasta_data.len);
     try std.testing.expect(idx.zfi_map != null);
-    try std.testing.expectEqualStrings("seq1", idx.getRecordName(0));
+    try std.testing.expectEqualStrings("seq1", idx.recordName(0).?);
 
     var first_byte: [1]u8 = undefined;
     try std.testing.expectEqual(
@@ -1877,7 +1992,7 @@ test "loadIndexCheckedWithMode positional rejects impossible fai geometry" {
 
     try std.testing.expectError(
         error.CorruptIndex,
-        main.index_format.loadIndexCheckedWithMode(io, fasta_path, .{ .positional = &.{"seq1"} }),
+        main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = &.{"seq1"} }),
     );
 }
 
@@ -1901,7 +2016,7 @@ test "stats loader rejects impossible fai geometry" {
 
     try std.testing.expectError(
         error.CorruptIndex,
-        main.index_format.loadIndexCheckedWithMode(io, fasta_path, .stats_scan),
+        main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .stats_scan),
     );
 }
 
@@ -2003,36 +2118,35 @@ test "streamed fai loading accepts the maximum sequence name" {
 
     {
         var idx = try main.index_format.loadIndexCheckedWithMode(
+            std.testing.allocator,
             io,
             fasta_path,
             .{ .positional = &.{name} },
         );
-        defer idx.deinit(io);
+        defer idx.deinit();
 
         try std.testing.expectEqual(@as(usize, 1), idx.records.len);
-        try std.testing.expectEqualStrings(name, idx.getRecordName(0));
+        try std.testing.expectEqualStrings(name, idx.recordName(0).?);
     }
     {
-        var idx = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .stats_scan);
-        defer idx.deinit(io);
+        var idx = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .stats_scan);
+        defer idx.deinit();
 
         try std.testing.expectEqual(@as(usize, 1), idx.records.len);
-        try std.testing.expectEqualStrings(name, idx.getRecordName(0));
-        try std.testing.expect(idx.fasta_map == null);
-        try std.testing.expectEqual(@as(usize, 0), idx.fasta_data.len);
+        try std.testing.expectEqualStrings(name, idx.recordName(0).?);
     }
 }
 
 fn expectFaiLoaderModesAgree(fasta_path: []const u8) !void {
-    var full = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .lookup_full_map);
-    defer full.deinit(io);
+    var full = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .lookup_full_map);
+    defer full.deinit();
     const names = try std.testing.allocator.alloc([]const u8, full.records.len);
     defer std.testing.allocator.free(names);
-    for (names, 0..) |*name, i| name.* = full.getRecordName(i);
-    var positional = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .{ .positional = names });
-    defer positional.deinit(io);
-    var stats_scan = try main.index_format.loadIndexCheckedWithMode(io, fasta_path, .stats_scan);
-    defer stats_scan.deinit(io);
+    for (names, 0..) |*name, i| name.* = full.recordName(i).?;
+    var positional = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = names });
+    defer positional.deinit();
+    var stats_scan = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .stats_scan);
+    defer stats_scan.deinit();
 
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, full.source);
     try std.testing.expectEqual(full.source, positional.source);
@@ -2040,8 +2154,6 @@ fn expectFaiLoaderModesAgree(fasta_path: []const u8) !void {
     try std.testing.expectEqual(full.records.len, positional.records.len);
     try std.testing.expectEqual(full.records.len, stats_scan.records.len);
     try std.testing.expectEqual(@as(usize, 2), stats_scan.name_slices.len);
-    try std.testing.expect(stats_scan.fasta_map == null);
-    try std.testing.expectEqual(@as(usize, 0), stats_scan.fasta_data.len);
 
     var shortest_index: usize = 0;
     var longest_index: usize = 0;
@@ -2050,8 +2162,8 @@ fn expectFaiLoaderModesAgree(fasta_path: []const u8) !void {
         if (rec.seq_len > full.records[longest_index].seq_len) longest_index = i;
     }
     try std.testing.expectEqual([2]usize{ shortest_index, longest_index }, stats_scan.stats_name_indices.?);
-    try std.testing.expectEqualStrings(full.getRecordName(shortest_index), stats_scan.getRecordName(shortest_index));
-    try std.testing.expectEqualStrings(full.getRecordName(longest_index), stats_scan.getRecordName(longest_index));
+    try std.testing.expectEqualStrings(full.recordName(shortest_index).?, stats_scan.recordName(shortest_index).?);
+    try std.testing.expectEqualStrings(full.recordName(longest_index).?, stats_scan.recordName(longest_index).?);
 
     for (full.records, 0..) |rec, i| {
         const streamed = positional.records[i];
@@ -2068,9 +2180,9 @@ fn expectFaiLoaderModesAgree(fasta_path: []const u8) !void {
         try std.testing.expectEqual(rec.line_bases, scanned.line_bases);
         try std.testing.expectEqual(rec.line_bytes, scanned.line_bytes);
 
-        try std.testing.expectEqualStrings(full.getRecordName(i), positional.getRecordName(i));
+        try std.testing.expectEqualStrings(full.recordName(i).?, positional.recordName(i).?);
         if (i != shortest_index and i != longest_index) {
-            try std.testing.expectEqualStrings("?", stats_scan.getRecordName(i));
+            try std.testing.expectEqual(null, stats_scan.recordName(i));
         }
     }
 }
@@ -2160,7 +2272,7 @@ test "loadIndexChecked accepts zfi when FASTA omits terminal newline" {
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
 
     var idx = try loadIndexChecked(io, fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     try std.testing.expectEqual(@as(u64, 4), idx.records[0].seq_len);
 }
@@ -2387,8 +2499,8 @@ test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
     defer allocator.free(zfi_bytes);
 
     // Strip production ZFID (between blob and footer): legacy weak identity.
-    const footer_len = main.index_format.zfi_name_footer_bytes;
-    const id_len = main.index_format.zfi_source_id_bytes;
+    const footer_len = main.index_format.ZFI_NAME_FOOTER_BYTES;
+    const id_len = main.index_format.ZFI_SOURCE_ID_BYTES;
     try std.testing.expect(zfi_bytes.len >= footer_len + id_len);
     const id_off = zfi_bytes.len - footer_len - id_len;
     try std.testing.expectEqualSlices(
@@ -2406,7 +2518,7 @@ test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
     var idx = try loadIndexChecked(io, paths.fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
 }
 
@@ -2421,8 +2533,8 @@ test "loadIndexChecked accepts embedded names with legacy 16-byte footer" {
     const zfi_bytes = try main.indexer.zfiIndexToBytes(&index, fasta_data.len, 0, allocator);
     defer allocator.free(zfi_bytes);
 
-    const footer_len = main.index_format.zfi_name_footer_bytes;
-    const id_len = main.index_format.zfi_source_id_bytes;
+    const footer_len = main.index_format.ZFI_NAME_FOOTER_BYTES;
+    const id_len = main.index_format.ZFI_SOURCE_ID_BYTES;
     const payload_end = zfi_bytes.len - footer_len - id_len;
     const name_len_bytes: *const [8]u8 = @ptrCast(zfi_bytes[zfi_bytes.len - 8 ..].ptr);
     const name_blob_len = std.mem.readInt(u64, name_len_bytes, .little);
@@ -2440,9 +2552,9 @@ test "loadIndexChecked accepts embedded names with legacy 16-byte footer" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
     var idx = try loadIndexChecked(io, paths.fasta_path);
-    defer idx.deinit(io);
+    defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
-    try std.testing.expectEqualStrings("seq1", idx.getRecordName(0));
+    try std.testing.expectEqualStrings("seq1", idx.recordName(0).?);
 }
 
 test "loadIndexChecked rejects zfi with wrong embedded source mtime" {

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -7,17 +7,16 @@ const std = @import("std");
 const builtin = @import("builtin");
 const main = @import("main");
 const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
-const validateFasta = main.validateFasta;
 const scanFaiData = main.indexer.scanFaiData;
-const index_read_buffer_size = main.indexer.index_read_buffer_size;
-const IndexRecord = main.IndexRecord;
-const ZfiHeader = main.ZfiHeader;
-const ZFI_MAGIC = main.ZFI_MAGIC;
+const INDEX_READ_BUFFER_SIZE = main.indexer.INDEX_READ_BUFFER_SIZE;
+const IndexRecord = main.index_format.IndexRecord;
+const ZfiHeader = main.index_format.ZfiHeader;
+const ZFI_MAGIC = main.index_format.ZFI_MAGIC;
 const c = std.c;
 const io = std.testing.io;
 
-fn loadIndexChecked(test_io: std.Io, fasta_path: []const u8) main.index_format.LoadIndexError!main.index_format.LoadedIndex {
-    return main.index_format.loadIndexChecked(std.testing.allocator, test_io, fasta_path);
+fn loadIndexChecked(allocator: std.mem.Allocator, test_io: std.Io, fasta_path: []const u8) main.index_format.LoadIndexError!main.index_format.LoadedIndex {
+    return main.index_format.loadIndexChecked(allocator, test_io, fasta_path);
 }
 
 fn loadAndDeinitForAllocationCheck(allocator: std.mem.Allocator, fasta_path: []const u8, mode: main.index_format.LoadMode) !void {
@@ -32,11 +31,14 @@ fn statMtimeNs(path: []const u8) !u64 {
     return main.index_format.timestampToNs(st.mtime);
 }
 
-/// Write FASTA + raw `.zfi` bytes, patching a `ZFID` trailer (before the name footer)
-/// to the FASTA mtime so load tests exercise structural checks instead of false staleness.
+// Patch a raw `.zfi` source identity so malformed-index tests reach structural checks.
 fn writeFastaAndRawZfi(allocator: std.mem.Allocator, stem: []const u8, fasta: []const u8, zfi_bytes: []const u8) !struct { fasta_path: []u8, zfi_path: []u8 } {
     const fasta_path = try uniqueArtifactPath(allocator, stem, "fa");
+    errdefer allocator.free(fasta_path);
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    errdefer allocator.free(zfi_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    errdefer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     {
         const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
@@ -87,6 +89,7 @@ fn uniqueArtifactDirPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
     const now = std.Io.Clock.Timestamp.now(io, .awake);
     const nanos: u64 = @intCast(now.raw.toNanoseconds());
     const path = try std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}", .{ stem, nanos });
+    errdefer allocator.free(path);
     try std.Io.Dir.cwd().createDirPath(io, path);
     return path;
 }
@@ -134,10 +137,6 @@ fn markFileStaleOneHourAgo(file: std.Io.File) !void {
     }
 }
 
-// ============================================================================
-// Test helper: read file into memory
-// ============================================================================
-
 fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => {
@@ -149,11 +148,13 @@ fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     defer file.close(io);
     const stat = try file.stat(io);
     const data = try allocator.alloc(u8, @intCast(stat.size));
+    errdefer allocator.free(data);
     const bytes_read = try std.Io.File.readPositionalAll(file, io, data, 0);
-    return data[0..bytes_read];
+    if (bytes_read != data.len) return error.UnexpectedEndOfFile;
+    return data;
 }
 
-fn scanRecordsForTest(data: []const u8, allocator: std.mem.Allocator) !std.ArrayList(IndexRecord) {
+fn scanRecordsForTest(allocator: std.mem.Allocator, data: []const u8) !std.ArrayList(IndexRecord) {
     var records: std.ArrayList(IndexRecord) = .empty;
     errdefer records.deinit(allocator);
 
@@ -181,7 +182,18 @@ fn scanRecordsForTest(data: []const u8, allocator: std.mem.Allocator) !std.Array
     return records;
 }
 
-/// In-repo fixtures required for CI. Missing path fails with a clear message.
+fn scanZfiForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !void {
+    var index = try main.indexer.scanZfiData(data, true, allocator);
+    defer index.deinit(allocator);
+}
+
+fn scanFaiForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !void {
+    var storage: [256]u8 = undefined;
+    var output = std.Io.Writer.fixed(&storage);
+    _ = try scanFaiData(data, &output, true, allocator);
+}
+
+// In-repo fixtures are required; absence is a test failure, not a skip.
 fn requireFixturePath(path: []const u8) !void {
     std.Io.Dir.cwd().access(io, path, .{}) catch |err| switch (err) {
         error.FileNotFound => {
@@ -192,18 +204,12 @@ fn requireFixturePath(path: []const u8) !void {
     };
 }
 
-/// Optional large or generated fixtures. Prints why and skips the test.
-fn skipOptionalFixture(path: []const u8, how_to_obtain: []const u8) error{SkipZigTest} {
-    std.debug.print("optional fixture absent, skipping: {s}\n  obtain via: {s}\n", .{ path, how_to_obtain });
-    return error.SkipZigTest;
-}
-
 fn scanFaiReaderForTest(
+    allocator: std.mem.Allocator,
     reader: *std.Io.Reader,
     read_buf: []u8,
     writer: *std.Io.Writer,
     enable_dedup: bool,
-    allocator: std.mem.Allocator,
 ) !u32 {
     const Sink = struct {
         writer: *std.Io.Writer,
@@ -271,11 +277,11 @@ fn expectReaderMatchesProduction(
         try std.testing.expectError(
             baseline_err,
             scanFaiReaderForTest(
+                allocator,
                 &fai_reader,
                 read_buf,
                 &fragmented_fai.writer,
                 enable_dedup,
-                allocator,
             ),
         );
         return;
@@ -285,11 +291,11 @@ fn expectReaderMatchesProduction(
     defer fragmented_fai.deinit();
     var fai_reader = std.Io.Reader.fixed(data);
     const fragmented_count = try scanFaiReaderForTest(
+        allocator,
         &fai_reader,
         read_buf,
         &fragmented_fai.writer,
         enable_dedup,
-        allocator,
     );
 
     try std.testing.expectEqual(baseline_count, fragmented_count);
@@ -299,93 +305,118 @@ fn expectReaderMatchesProduction(
     };
 }
 
-// ============================================================================
-// validateFasta tests
-// ============================================================================
-
-test "validateFasta returns true for valid FASTA" {
-    try std.testing.expect(validateFasta(">seq1\nACGT\n"));
+fn appendZfiHeader(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, record_count: u32, source_size: u64) !void {
+    const header = ZfiHeader{
+        .magic = ZFI_MAGIC,
+        .record_count = record_count,
+        .source_size = source_size,
+    };
+    try buf.appendSlice(allocator, std.mem.asBytes(&header));
 }
 
-test "validateFasta returns true for just header" {
-    try std.testing.expect(validateFasta(">"));
+fn expectFaiLoaderModesAgree(allocator: std.mem.Allocator, fasta_path: []const u8) !void {
+    var full = try main.index_format.loadIndexCheckedWithMode(allocator, io, fasta_path, .lookup_full_map);
+    defer full.deinit();
+    const names = try allocator.alloc([]const u8, full.records.len);
+    defer allocator.free(names);
+    for (names, 0..) |*name, i| name.* = full.recordName(i).?;
+    var positional = try main.index_format.loadIndexCheckedWithMode(allocator, io, fasta_path, .{ .positional = names });
+    defer positional.deinit();
+    var stats_scan = try main.index_format.loadIndexCheckedWithMode(allocator, io, fasta_path, .stats_scan);
+    defer stats_scan.deinit();
+
+    try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, full.source);
+    try std.testing.expectEqual(full.source, positional.source);
+    try std.testing.expectEqual(full.source, stats_scan.source);
+    try std.testing.expectEqual(full.records.len, positional.records.len);
+    try std.testing.expectEqual(full.records.len, stats_scan.records.len);
+    try std.testing.expectEqual(@as(usize, 2), stats_scan.name_slices.len);
+
+    var shortest_index: usize = 0;
+    var longest_index: usize = 0;
+    for (full.records[1..], 1..) |rec, i| {
+        if (rec.seq_len < full.records[shortest_index].seq_len) shortest_index = i;
+        if (rec.seq_len > full.records[longest_index].seq_len) longest_index = i;
+    }
+    try std.testing.expectEqual([2]usize{ shortest_index, longest_index }, stats_scan.stats_name_indices.?);
+    try std.testing.expectEqualStrings(full.recordName(shortest_index).?, stats_scan.recordName(shortest_index).?);
+    try std.testing.expectEqualStrings(full.recordName(longest_index).?, stats_scan.recordName(longest_index).?);
+
+    for (full.records, 0..) |rec, i| {
+        const streamed = positional.records[i];
+        const scanned = stats_scan.records[i];
+
+        try std.testing.expectEqual(rec.seq_offset, streamed.seq_offset);
+        try std.testing.expectEqual(rec.seq_len, streamed.seq_len);
+        try std.testing.expectEqual(rec.line_bases, streamed.line_bases);
+        try std.testing.expectEqual(rec.line_bytes, streamed.line_bytes);
+
+        try std.testing.expectEqual(rec.seq_offset, scanned.seq_offset);
+        try std.testing.expectEqual(rec.seq_len, scanned.seq_len);
+        try std.testing.expectEqual(rec.line_bases, scanned.line_bases);
+        try std.testing.expectEqual(rec.line_bytes, scanned.line_bytes);
+
+        try std.testing.expectEqualStrings(full.recordName(i).?, positional.recordName(i).?);
+        if (i != shortest_index and i != longest_index) {
+            try std.testing.expectEqual(null, stats_scan.recordName(i));
+        }
+    }
 }
 
-test "validateFasta returns false for empty data" {
-    try std.testing.expect(!validateFasta(""));
+fn expectCorruptFaiFixture(allocator: std.mem.Allocator, stem: []const u8) !void {
+    const src_fa = try std.fmt.allocPrint(allocator, "{s}.fasta", .{stem});
+    const src_fai = try std.fmt.allocPrint(allocator, "{s}.fasta.fai", .{stem});
+    const fasta_data = try readTestFile(allocator, src_fa);
+    defer allocator.free(fasta_data);
+    const fai_data = try readTestFile(allocator, src_fai);
+    defer allocator.free(fai_data);
+
+    const fasta_path = try uniqueArtifactPath(allocator, "gates-fai", "fa");
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
+    }
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
+        defer fai_file.close(io);
+        try std.Io.File.writeStreamingAll(fai_file, io, fai_data);
+    }
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
-test "validateFasta returns false for non-FASTA" {
-    try std.testing.expect(!validateFasta("not fasta"));
-    try std.testing.expect(!validateFasta("ACGT"));
-    try std.testing.expect(!validateFasta("\n>seq"));
-    try std.testing.expect(!validateFasta(" >seq"));
-}
+// --- FASTA reader tests ---
 
-test "validateFasta on real file - valid" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const data = try readTestFile(arena.allocator(), "tests/data/simple.fasta");
-    try std.testing.expect(validateFasta(data));
-}
-
-test "validateFasta on real file - invalid" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const data = try readTestFile(arena.allocator(), "tests/data/not_fasta.txt");
-    try std.testing.expect(!validateFasta(data));
-}
-
-// ============================================================================
-// scanRecordsForTest tests
-// ============================================================================
-
-test "scanRecordsForTest basic" {
-    const data = ">seq1\nACGT\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(data, arena.allocator());
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-
-    const rec = records.items[0];
-    try std.testing.expectEqualStrings("seq1", rec.getName(data));
-    try std.testing.expectEqual(@as(u64, 4), rec.seq_len);
-    try std.testing.expectEqual(@as(u64, 6), rec.seq_offset);
-    try std.testing.expectEqual(@as(u32, 4), rec.line_bases);
-    try std.testing.expectEqual(@as(u32, 5), rec.line_bytes);
-}
-
-test "scanRecordsForTest multiple sequences" {
+test "FASTA scan records names and geometry" {
     const data = ">seq1\nACGT\n>seq2\nGGGG\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 2), records.items.len);
 
     try std.testing.expectEqualStrings("seq1", records.items[0].getName(data));
     try std.testing.expectEqualStrings("seq2", records.items[1].getName(data));
+    try std.testing.expectEqual(@as(u64, 4), records.items[0].seq_len);
+    try std.testing.expectEqual(@as(u64, 6), records.items[0].seq_offset);
+    try std.testing.expectEqual(@as(u64, 17), records.items[1].seq_offset);
+    try std.testing.expectEqual(@as(u32, 4), records.items[0].line_bases);
+    try std.testing.expectEqual(@as(u32, 5), records.items[0].line_bytes);
 }
 
-test "scanRecordsForTest with header description" {
-    const data = ">myseq some description here\nACGT\n";
+test "FASTA scan retains identifiers and discards descriptions" {
+    const data = ">myseq some description here\nACGT\n>sp|P12345|PROT_NAME OS=Human\nACGT\n";
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
+    const records = try scanRecordsForTest(arena.allocator(), data);
+    try std.testing.expectEqual(@as(usize, 2), records.items.len);
     try std.testing.expectEqualStrings("myseq", records.items[0].getName(data));
-}
-
-test "scanRecordsForTest with pipe-delimited header (proteome style)" {
-    const data = ">sp|P12345|PROT_NAME OS=Human\nACGT\n";
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-
-    const records = try scanRecordsForTest(data, arena.allocator());
-    try std.testing.expectEqual(@as(usize, 1), records.items.len);
-    try std.testing.expectEqualStrings("sp|P12345|PROT_NAME", records.items[0].getName(data));
+    try std.testing.expectEqualStrings("sp|P12345|PROT_NAME", records.items[1].getName(data));
 }
 
 test "scanRecordsForTest multiline sequence" {
@@ -393,7 +424,7 @@ test "scanRecordsForTest multiline sequence" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
 
     const rec = records.items[0];
@@ -407,7 +438,7 @@ test "scanRecordsForTest counts wrapped final short line with trailing newline c
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
 
     const rec = records.items[0];
@@ -421,7 +452,7 @@ test "scanRecordsForTest counts trailing whitespace lines via base scan fallback
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
     try std.testing.expectEqual(@as(u64, 12), records.items[0].seq_len);
 }
@@ -431,7 +462,7 @@ test "scanRecordsForTest counts record with trailing newline before next header"
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
     try std.testing.expectEqual(@as(u64, 4), records.items[0].seq_len);
 }
@@ -441,7 +472,7 @@ test "scanRecordsForTest cross-checks non-dense first line against countBases" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
     try std.testing.expectEqual(@as(u64, 12), records.items[0].seq_len);
 }
@@ -451,7 +482,7 @@ test "scanRecordsForTest handles CRLF line endings" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
 
     const rec = records.items[0];
@@ -465,7 +496,7 @@ test "scanRecordsForTest skips empty sequences (matches samtools)" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
     try std.testing.expectEqualStrings("next", records.items[0].getName(data));
 }
@@ -475,20 +506,10 @@ test "scanRecordsForTest skips duplicate names (matches samtools)" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
 
-    const records = try scanRecordsForTest(data, arena.allocator());
+    const records = try scanRecordsForTest(arena.allocator(), data);
     try std.testing.expectEqual(@as(usize, 2), records.items.len);
     try std.testing.expectEqualStrings("dup", records.items[0].getName(data));
     try std.testing.expectEqualStrings("other", records.items[1].getName(data));
-}
-
-test "NameDedup identity is string equality" {
-    var seen = main.indexer.NameDedup.init(std.testing.allocator);
-    defer seen.deinit();
-
-    try std.testing.expect(!(try seen.observe("alpha")));
-    try std.testing.expect(try seen.observe("alpha"));
-    try std.testing.expect(!(try seen.observe("beta")));
-    try std.testing.expect(try seen.observe("beta"));
 }
 
 test "FAI dedup keeps first occurrence and distinct names" {
@@ -498,6 +519,7 @@ test "FAI dedup keeps first occurrence and distinct names" {
     const allocator = arena.allocator();
 
     var fai = std.Io.Writer.Allocating.init(allocator);
+    defer fai.deinit();
     const count = try scanFaiData(data, &fai.writer, true, allocator);
 
     try std.testing.expectEqual(@as(u32, 3), count);
@@ -506,34 +528,22 @@ test "FAI dedup keeps first occurrence and distinct names" {
     try std.testing.expect(std.mem.indexOf(u8, fai.written(), "also\t") != null);
 }
 
-test "scanRecordsForTest on real simple.fasta file" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const data = try readTestFile(arena.allocator(), "tests/data/simple.fasta");
+test "index scans release allocations on every failure path" {
+    const data = ">alpha\nAAAA\n>beta\nCCCC\n>alpha\nGGGG\n";
 
-    const records = try scanRecordsForTest(data, arena.allocator());
-    try std.testing.expectEqual(@as(usize, 2), records.items.len);
-
-    try std.testing.expectEqualStrings("seq1", records.items[0].getName(data));
-    try std.testing.expectEqual(@as(u64, 24), records.items[0].seq_len);
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        scanZfiForAllocationCheck,
+        .{data},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        scanFaiForAllocationCheck,
+        .{data},
+    );
 }
 
-test "scanRecordsForTest on real proteome.fasta file" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const data = try readTestFile(arena.allocator(), "tests/data/proteome.fasta");
-
-    const records = try scanRecordsForTest(data, arena.allocator());
-    try std.testing.expect(records.items.len > 0);
-
-    // Proteome headers have pipes
-    const name = records.items[0].getName(data);
-    try std.testing.expect(std.mem.indexOf(u8, name, "|") != null);
-}
-
-// ============================================================================
-// writeZfiIndex tests
-// ============================================================================
+// --- ZFI wire format ---
 
 test "writeZfiIndexFile creates valid production layout" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -554,7 +564,8 @@ test "writeZfiIndexFile creates valid production layout" {
     const stat = try file.stat(io);
 
     var header_bytes: [@sizeOf(ZfiHeader)]u8 = undefined;
-    _ = try std.Io.File.readPositionalAll(file, io, &header_bytes, 0);
+    const header_bytes_read = try std.Io.File.readPositionalAll(file, io, &header_bytes, 0);
+    try std.testing.expectEqual(header_bytes.len, header_bytes_read);
     const header: ZfiHeader = @bitCast(header_bytes);
 
     try std.testing.expectEqualSlices(u8, &ZFI_MAGIC, &header.magic);
@@ -568,16 +579,9 @@ test "writeZfiIndexFile creates valid production layout" {
     );
 }
 
-test "ZfiHeader has correct size" {
+test "zfi wire structs retain frozen sizes" {
     try std.testing.expectEqual(@as(usize, 16), @sizeOf(ZfiHeader));
-}
-
-test "IndexRecord has consistent size" {
-    // name_offset(8) + name_len(2) + padding(6) + seq_offset(8) + seq_len(8) + line_bases(4) + line_bytes(4) = 40
     try std.testing.expectEqual(@as(usize, 40), @sizeOf(IndexRecord));
-}
-
-test "SideTableLine has explicit v0.3 size" {
     try std.testing.expectEqual(@as(usize, 32), @sizeOf(main.index_format.SideTableLine));
 }
 
@@ -685,7 +689,7 @@ test "scanZfiReader zfi loads record names" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    var idx = try loadIndexChecked(io, paths.fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, paths.fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(@as(?usize, 0), idx.lookupName("seq1"));
     try std.testing.expectEqual(@as(?usize, 1), idx.lookupName("seq2"));
@@ -699,7 +703,7 @@ test "indexing crosses the production read boundary" {
     var fasta: std.ArrayList(u8) = .empty;
     defer fasta.deinit(allocator);
     try fasta.appendSlice(allocator, ">seq1\n");
-    try fasta.appendNTimes(allocator, 'A', index_read_buffer_size + 10);
+    try fasta.appendNTimes(allocator, 'A', INDEX_READ_BUFFER_SIZE + 10);
     try fasta.appendSlice(allocator, "\n>seq2\nACGT\n");
 
     var output = std.Io.Writer.Allocating.init(allocator);
@@ -709,10 +713,10 @@ test "indexing crosses the production read boundary" {
         allocator,
         "seq1\t{d}\t6\t{d}\t{d}\nseq2\t4\t{d}\t4\t5\n",
         .{
-            index_read_buffer_size + 10,
-            index_read_buffer_size + 10,
-            index_read_buffer_size + 11,
-            index_read_buffer_size + 23,
+            INDEX_READ_BUFFER_SIZE + 10,
+            INDEX_READ_BUFFER_SIZE + 10,
+            INDEX_READ_BUFFER_SIZE + 11,
+            INDEX_READ_BUFFER_SIZE + 23,
         },
     );
 
@@ -722,12 +726,12 @@ test "indexing crosses the production read boundary" {
     var index = try main.indexer.scanZfiData(fasta.items, true, allocator);
     defer index.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 2), index.records.items.len);
-    try std.testing.expectEqual(@as(u64, index_read_buffer_size + 10), index.records.items[0].seq_len);
+    try std.testing.expectEqual(@as(u64, INDEX_READ_BUFFER_SIZE + 10), index.records.items[0].seq_len);
     try std.testing.expectEqual(@as(u64, 6), index.records.items[0].seq_offset);
-    try std.testing.expectEqual(@as(u32, index_read_buffer_size + 10), index.records.items[0].line_bases);
-    try std.testing.expectEqual(@as(u32, index_read_buffer_size + 11), index.records.items[0].line_bytes);
+    try std.testing.expectEqual(@as(u32, INDEX_READ_BUFFER_SIZE + 10), index.records.items[0].line_bases);
+    try std.testing.expectEqual(@as(u32, INDEX_READ_BUFFER_SIZE + 11), index.records.items[0].line_bytes);
     try std.testing.expectEqual(@as(u64, 4), index.records.items[1].seq_len);
-    try std.testing.expectEqual(@as(u64, index_read_buffer_size + 23), index.records.items[1].seq_offset);
+    try std.testing.expectEqual(@as(u64, INDEX_READ_BUFFER_SIZE + 23), index.records.items[1].seq_offset);
     const second_name = index.name_blob.items[index.records.items[1].name_offset..][0..index.records.items[1].name_len];
     try std.testing.expectEqualStrings("seq2", second_name);
 }
@@ -737,7 +741,7 @@ test "indexing handles a header name split at the production read boundary" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const chunk = index_read_buffer_size;
+    const chunk = INDEX_READ_BUFFER_SIZE;
     var fasta: std.ArrayList(u8) = .empty;
     defer fasta.deinit(allocator);
     try fasta.appendSlice(allocator, ">seq1\n");
@@ -780,9 +784,9 @@ test "reader-size matrix matches both formats across token boundaries" {
         line_bytes - 1,
         line_bytes,
         line_bytes + 1,
-        index_read_buffer_size,
+        INDEX_READ_BUFFER_SIZE,
     };
-    const read_storage = try allocator.alloc(u8, index_read_buffer_size);
+    const read_storage = try allocator.alloc(u8, INDEX_READ_BUFFER_SIZE);
     for ([_]bool{ false, true }) |enable_dedup| {
         for (read_sizes) |read_size| {
             try expectReaderMatchesProduction(
@@ -804,7 +808,7 @@ test "header limit is exact across read fragments" {
     var fasta: std.ArrayList(u8) = .empty;
     defer fasta.deinit(allocator);
     try fasta.append(allocator, '>');
-    try fasta.appendNTimes(allocator, 'A', main.indexer.max_index_name_len);
+    try fasta.appendNTimes(allocator, 'A', main.indexer.MAX_INDEX_NAME_LEN);
     try fasta.appendSlice(allocator, "\nACGT\n");
 
     var read_storage: [31]u8 = undefined;
@@ -818,7 +822,7 @@ test "header limit is exact across read fragments" {
         );
     }
 
-    try fasta.insert(allocator, main.indexer.max_index_name_len + 1, 'A');
+    try fasta.insert(allocator, main.indexer.MAX_INDEX_NAME_LEN + 1, 'A');
     for ([_]bool{ false, true }) |enable_dedup| {
         var zfi_reader = std.Io.Reader.fixed(fasta.items);
         try std.testing.expectError(
@@ -837,11 +841,11 @@ test "header limit is exact across read fragments" {
         try std.testing.expectError(
             error.HeaderTooLong,
             scanFaiReaderForTest(
+                allocator,
                 &fai_reader,
                 &read_storage,
                 &fai.writer,
                 enable_dedup,
-                allocator,
             ),
         );
     }
@@ -855,7 +859,7 @@ test "indexing handles a sequence split at the production read boundary" {
     var fasta: std.ArrayList(u8) = .empty;
     defer fasta.deinit(allocator);
     try fasta.appendSlice(allocator, ">seq1\n");
-    try fasta.appendNTimes(allocator, 'A', index_read_buffer_size);
+    try fasta.appendNTimes(allocator, 'A', INDEX_READ_BUFFER_SIZE);
     try fasta.appendSlice(allocator, "ACGT\n");
 
     var output = std.Io.Writer.Allocating.init(allocator);
@@ -864,7 +868,7 @@ test "indexing handles a sequence split at the production read boundary" {
     const expected = try std.fmt.allocPrint(
         allocator,
         "seq1\t{d}\t6\t{d}\t{d}\n",
-        .{ index_read_buffer_size + 4, index_read_buffer_size + 4, index_read_buffer_size + 5 },
+        .{ INDEX_READ_BUFFER_SIZE + 4, INDEX_READ_BUFFER_SIZE + 4, INDEX_READ_BUFFER_SIZE + 5 },
     );
 
     try std.testing.expectEqual(@as(u32, 1), count);
@@ -873,9 +877,9 @@ test "indexing handles a sequence split at the production read boundary" {
     var index = try main.indexer.scanZfiData(fasta.items, true, allocator);
     defer index.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 1), index.records.items.len);
-    try std.testing.expectEqual(@as(u64, index_read_buffer_size + 4), index.records.items[0].seq_len);
-    try std.testing.expectEqual(@as(u32, index_read_buffer_size + 4), index.records.items[0].line_bases);
-    try std.testing.expectEqual(@as(u32, index_read_buffer_size + 5), index.records.items[0].line_bytes);
+    try std.testing.expectEqual(@as(u64, INDEX_READ_BUFFER_SIZE + 4), index.records.items[0].seq_len);
+    try std.testing.expectEqual(@as(u32, INDEX_READ_BUFFER_SIZE + 4), index.records.items[0].line_bases);
+    try std.testing.expectEqual(@as(u32, INDEX_READ_BUFFER_SIZE + 5), index.records.items[0].line_bytes);
 }
 
 test "FAI counts wrapped final short line with trailing newline correctly" {
@@ -885,6 +889,7 @@ test "FAI counts wrapped final short line with trailing newline correctly" {
     const allocator = arena.allocator();
 
     var out = std.Io.Writer.Allocating.init(allocator);
+    defer out.deinit();
     const record_count = try scanFaiData(data, &out.writer, true, allocator);
 
     try std.testing.expectEqual(@as(u32, 1), record_count);
@@ -899,10 +904,11 @@ test "indexing rejects sequence names longer than u16" {
     var fasta: std.ArrayList(u8) = .empty;
     defer fasta.deinit(allocator);
     try fasta.append(allocator, '>');
-    try fasta.appendNTimes(allocator, 'A', main.indexer.max_index_name_len + 1);
+    try fasta.appendNTimes(allocator, 'A', main.indexer.MAX_INDEX_NAME_LEN + 1);
     try fasta.appendSlice(allocator, "\nACGT\n");
 
     var output = std.Io.Writer.Allocating.init(allocator);
+    defer output.deinit();
 
     try std.testing.expectError(
         error.HeaderTooLong,
@@ -921,7 +927,7 @@ test "FAI uses the first base-bearing line after a blank" {
     _ = try scanFaiData(data, &output.writer, true, allocator);
     try std.testing.expectEqualStrings("seq\t4\t6\t4\t5\n", output.written());
 
-    var records = try scanRecordsForTest(data, allocator);
+    var records = try scanRecordsForTest(allocator, data);
     defer records.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 1), records.items.len);
     // First base-bearing line starts after the blank line (`>seq\n\n` = 6 bytes).
@@ -1064,7 +1070,7 @@ test "empty sequence name: ZFI loads and looks up like samtools FAI" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    var idx = try loadIndexChecked(io, paths.fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, paths.fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(@as(usize, 1), idx.records.len);
     try std.testing.expectEqualStrings("", idx.recordName(0).?);
@@ -1110,7 +1116,7 @@ test "empty sequence name: FAI text loads and resolves empty lookup" {
         try std.Io.File.writeStreamingAll(fai_file, io, "\t4\t2\t4\t5\n");
     }
 
-    var idx = try loadIndexChecked(io, fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(@as(usize, 1), idx.records.len);
     try std.testing.expectEqualStrings("", idx.recordName(0).?);
@@ -1129,6 +1135,7 @@ test "FAI accepts long sequence names within the limit" {
     try fasta.appendSlice(allocator, " description\nACGT\n");
 
     var output = std.Io.Writer.Allocating.init(allocator);
+    defer output.deinit();
     const count = try scanFaiData(fasta.items, &output.writer, true, allocator);
     try std.testing.expectEqual(@as(u32, 1), count);
     try std.testing.expect(std.mem.startsWith(u8, output.written(), fasta.items[1..10_001]));
@@ -1153,7 +1160,7 @@ test "loadIndexChecked rejects corrupt zfi records" {
     index.records.items[0].name_offset = 999_999;
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, 11, try statMtimeNs(fasta_path));
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects seq_offset at end of file" {
@@ -1176,16 +1183,7 @@ test "loadIndexChecked rejects seq_offset at end of file" {
     index.records.items[0].seq_offset = fasta_data.len;
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
-}
-
-fn appendZfiHeader(buf: *std.ArrayListUnmanaged(u8), allocator: std.mem.Allocator, record_count: u32, source_size: u64) !void {
-    const header = ZfiHeader{
-        .magic = ZFI_MAGIC,
-        .record_count = record_count,
-        .source_size = source_size,
-    };
-    try buf.appendSlice(allocator, std.mem.asBytes(&header));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects zfi with zero record_count" {
@@ -1201,7 +1199,7 @@ test "loadIndexChecked rejects zfi with zero record_count" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects truncated zfi header" {
@@ -1213,7 +1211,7 @@ test "loadIndexChecked rejects truncated zfi header" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi record_count larger than file" {
@@ -1232,7 +1230,7 @@ test "loadIndexChecked rejects zfi record_count larger than file" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi with bad magic" {
@@ -1251,7 +1249,7 @@ test "loadIndexChecked rejects zfi with bad magic" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi name blob overlapping records" {
@@ -1274,7 +1272,7 @@ test "loadIndexChecked rejects zfi name blob overlapping records" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi side table offset into records" {
@@ -1297,7 +1295,7 @@ test "loadIndexChecked rejects zfi side table offset into records" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi side table with empty line_count" {
@@ -1319,7 +1317,7 @@ test "loadIndexChecked rejects zfi side table with empty line_count" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects malformed zfi side table lines" {
@@ -1371,7 +1369,7 @@ test "loadIndexChecked rejects malformed zfi side table lines" {
         defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
         defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-        try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+        try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
     }
 }
 
@@ -1397,7 +1395,7 @@ test "loadIndexChecked rejects overlapping zfi side tables" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects mixed nameInZfi flags" {
@@ -1421,7 +1419,7 @@ test "loadIndexChecked rejects mixed nameInZfi flags" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects FASTA-backed zfi names" {
@@ -1442,7 +1440,7 @@ test "loadIndexChecked rejects FASTA-backed zfi names" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked accepts production zfi with side tables and name blob" {
@@ -1460,7 +1458,7 @@ test "loadIndexChecked accepts production zfi with side tables and name blob" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    var idx = try loadIndexChecked(io, paths.fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, paths.fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     try std.testing.expect(idx.name_blob != null);
@@ -1560,7 +1558,7 @@ test "loadIndexChecked uses valid zfi and rejects it when stale despite valid fa
     try fai_fw.flush();
 
     {
-        var idx = try loadIndexChecked(io, fasta_path);
+        var idx = try loadIndexChecked(std.testing.allocator, io, fasta_path);
         defer idx.deinit();
         try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     }
@@ -1569,7 +1567,7 @@ test "loadIndexChecked uses valid zfi and rejects it when stale despite valid fa
     defer zfi_file.close(io);
     try markFileStaleOneHourAgo(zfi_file);
 
-    try std.testing.expectError(error.StaleIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects invalid present zfi despite valid fai" {
@@ -1607,7 +1605,7 @@ test "loadIndexChecked rejects invalid present zfi despite valid fai" {
             defer zfi_file.close(io);
             try std.Io.File.writeStreamingAll(zfi_file, io, bytes);
         }
-        try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+        try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
     }
 }
 
@@ -1648,7 +1646,7 @@ test "loadIndexChecked reports an inaccessible selected sidecar" {
         const permissions = (try zfi_file.stat(io)).permissions;
         try zfi_file.setPermissions(io, no_permissions);
         defer zfi_file.setPermissions(io, permissions) catch {};
-        try std.testing.expectError(error.AccessDenied, loadIndexChecked(io, fasta_path));
+        try std.testing.expectError(error.AccessDenied, loadIndexChecked(std.testing.allocator, io, fasta_path));
     }
 
     try std.Io.Dir.cwd().deleteFile(io, zfi_path);
@@ -1658,7 +1656,7 @@ test "loadIndexChecked reports an inaccessible selected sidecar" {
         const permissions = (try fai_file.stat(io)).permissions;
         try fai_file.setPermissions(io, no_permissions);
         defer fai_file.setPermissions(io, permissions) catch {};
-        try std.testing.expectError(error.AccessDenied, loadIndexChecked(io, fasta_path));
+        try std.testing.expectError(error.AccessDenied, loadIndexChecked(std.testing.allocator, io, fasta_path));
     }
 }
 
@@ -1905,7 +1903,7 @@ test "loadIndexChecked rejects fai with zero line_bases" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t0\t5\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects fai with line_bytes less than line_bases" {
@@ -1926,7 +1924,7 @@ test "loadIndexChecked rejects fai with line_bytes less than line_bases" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t5\t4\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects fai with seq_offset past EOF" {
@@ -1947,7 +1945,7 @@ test "loadIndexChecked rejects fai with seq_offset past EOF" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t99\t4\t5\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects fai whose sequence span exceeds FASTA" {
@@ -1969,7 +1967,7 @@ test "loadIndexChecked rejects fai whose sequence span exceeds FASTA" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t100\t6\t4\t5\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexCheckedWithMode positional rejects impossible fai geometry" {
@@ -2039,7 +2037,7 @@ test "loadIndexChecked rejects fai decimal overflow in seq_len" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t99999999999999999999\t6\t4\t5\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects fai line_bases above u32" {
@@ -2060,7 +2058,7 @@ test "loadIndexChecked rejects fai line_bases above u32" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t4294967296\t5\n");
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects fai name longer than u16" {
@@ -2086,7 +2084,7 @@ test "loadIndexChecked rejects fai name longer than u16" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, fai_buf.items);
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "streamed fai loading accepts the maximum sequence name" {
@@ -2137,56 +2135,6 @@ test "streamed fai loading accepts the maximum sequence name" {
     }
 }
 
-fn expectFaiLoaderModesAgree(fasta_path: []const u8) !void {
-    var full = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .lookup_full_map);
-    defer full.deinit();
-    const names = try std.testing.allocator.alloc([]const u8, full.records.len);
-    defer std.testing.allocator.free(names);
-    for (names, 0..) |*name, i| name.* = full.recordName(i).?;
-    var positional = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .{ .positional = names });
-    defer positional.deinit();
-    var stats_scan = try main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .stats_scan);
-    defer stats_scan.deinit();
-
-    try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.fai, full.source);
-    try std.testing.expectEqual(full.source, positional.source);
-    try std.testing.expectEqual(full.source, stats_scan.source);
-    try std.testing.expectEqual(full.records.len, positional.records.len);
-    try std.testing.expectEqual(full.records.len, stats_scan.records.len);
-    try std.testing.expectEqual(@as(usize, 2), stats_scan.name_slices.len);
-
-    var shortest_index: usize = 0;
-    var longest_index: usize = 0;
-    for (full.records[1..], 1..) |rec, i| {
-        if (rec.seq_len < full.records[shortest_index].seq_len) shortest_index = i;
-        if (rec.seq_len > full.records[longest_index].seq_len) longest_index = i;
-    }
-    try std.testing.expectEqual([2]usize{ shortest_index, longest_index }, stats_scan.stats_name_indices.?);
-    try std.testing.expectEqualStrings(full.recordName(shortest_index).?, stats_scan.recordName(shortest_index).?);
-    try std.testing.expectEqualStrings(full.recordName(longest_index).?, stats_scan.recordName(longest_index).?);
-
-    for (full.records, 0..) |rec, i| {
-        const streamed = positional.records[i];
-        const scanned = stats_scan.records[i];
-
-        // Geometry and length fields must match across loader modes.
-        try std.testing.expectEqual(rec.seq_offset, streamed.seq_offset);
-        try std.testing.expectEqual(rec.seq_len, streamed.seq_len);
-        try std.testing.expectEqual(rec.line_bases, streamed.line_bases);
-        try std.testing.expectEqual(rec.line_bytes, streamed.line_bytes);
-
-        try std.testing.expectEqual(rec.seq_offset, scanned.seq_offset);
-        try std.testing.expectEqual(rec.seq_len, scanned.seq_len);
-        try std.testing.expectEqual(rec.line_bases, scanned.line_bases);
-        try std.testing.expectEqual(rec.line_bytes, scanned.line_bytes);
-
-        try std.testing.expectEqualStrings(full.recordName(i).?, positional.recordName(i).?);
-        if (i != shortest_index and i != longest_index) {
-            try std.testing.expectEqual(null, stats_scan.recordName(i));
-        }
-    }
-}
-
 test "fai loaders agree when index omits terminal newline" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -2206,7 +2154,7 @@ test "fai loaders agree when index omits terminal newline" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "s1\t4\t4\t4\t5\ns2\t6\t13\t6\t7\ns3\t5\t24\t5\t6");
 
-    try expectFaiLoaderModesAgree(fasta_path);
+    try expectFaiLoaderModesAgree(allocator, fasta_path);
 }
 
 test "fai loaders agree when FASTA omits terminal newline" {
@@ -2228,7 +2176,7 @@ test "fai loaders agree when FASTA omits terminal newline" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t4\t6\t4\t5\n");
 
-    try expectFaiLoaderModesAgree(fasta_path);
+    try expectFaiLoaderModesAgree(allocator, fasta_path);
 }
 
 test "fai loaders agree when FASTA and index both omit terminal newline" {
@@ -2249,7 +2197,7 @@ test "fai loaders agree when FASTA and index both omit terminal newline" {
     defer fai_file.close(io);
     try std.Io.File.writeStreamingAll(fai_file, io, "seq1\t8\t6\t4\t5");
 
-    try expectFaiLoaderModesAgree(fasta_path);
+    try expectFaiLoaderModesAgree(allocator, fasta_path);
 }
 
 test "loadIndexChecked accepts zfi when FASTA omits terminal newline" {
@@ -2271,7 +2219,7 @@ test "loadIndexChecked accepts zfi when FASTA omits terminal newline" {
     defer index.deinit(allocator);
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
 
-    var idx = try loadIndexChecked(io, fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     try std.testing.expectEqual(@as(u64, 4), idx.records[0].seq_len);
@@ -2445,7 +2393,7 @@ test "loadIndexChecked rejects zfi after FASTA size change" {
         try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGTT\n");
     }
 
-    try std.testing.expectError(error.StaleIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects zfi after same-size FASTA replacement" {
@@ -2484,7 +2432,7 @@ test "loadIndexChecked rejects zfi after same-size FASTA replacement" {
         });
     }
 
-    try std.testing.expectError(error.StaleIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
@@ -2517,7 +2465,7 @@ test "loadIndexChecked accepts legacy zfi without source-identity trailer" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    var idx = try loadIndexChecked(io, paths.fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, paths.fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
 }
@@ -2551,7 +2499,7 @@ test "loadIndexChecked accepts embedded names with legacy 16-byte footer" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    var idx = try loadIndexChecked(io, paths.fasta_path);
+    var idx = try loadIndexChecked(std.testing.allocator, io, paths.fasta_path);
     defer idx.deinit();
     try std.testing.expectEqual(main.index_format.LoadedIndex.IndexSource.zfi, idx.source);
     try std.testing.expectEqualStrings("seq1", idx.recordName(0).?);
@@ -2587,7 +2535,7 @@ test "loadIndexChecked rejects zfi with wrong embedded source mtime" {
         try std.Io.File.writeStreamingAll(zfi_file, io, zfi_bytes);
     }
 
-    try std.testing.expectError(error.StaleIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.StaleIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "loadIndexChecked rejects truncated zfi mid-record" {
@@ -2604,7 +2552,7 @@ test "loadIndexChecked rejects truncated zfi mid-record" {
     defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, paths.zfi_path) catch {};
 
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, paths.fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, paths.fasta_path));
 }
 
 test "loadIndexChecked rejects zfi with zero line geometry" {
@@ -2627,7 +2575,7 @@ test "loadIndexChecked rejects zfi with zero line geometry" {
     defer index.deinit(allocator);
     index.records.items[0].line_bases = 0;
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }
 
 test "reader keeps trailing-blank record uniform" {
@@ -2772,7 +2720,7 @@ test "short final line across read boundary stays uniform" {
     defer fasta.deinit(allocator);
     try fasta.appendSlice(allocator, ">seq\n");
     const full_line = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"; // 60 + nl
-    while (fasta.items.len + full_line.len < index_read_buffer_size + 200) {
+    while (fasta.items.len + full_line.len < INDEX_READ_BUFFER_SIZE + 200) {
         try fasta.appendSlice(allocator, full_line);
     }
     try fasta.appendSlice(allocator, "ACGT\n");
@@ -2925,9 +2873,7 @@ test "short final plus next header spanning stride width preserves the next reco
     try std.testing.expectEqualStrings("b", n1);
 }
 
-// ============================================================================
-// Stable gates fixtures (tests/data/gates): malformed, boundary, portability
-// ============================================================================
+// --- Stable gates fixtures ---
 
 test "gates fixture: duplicate names keep first occurrence" {
     try requireFixturePath("tests/data/gates/duplicates.fasta");
@@ -2970,8 +2916,8 @@ test "gates fixture: long header indexes and over-u16 name rejects" {
     defer allocator.free(reject_data);
     try std.testing.expect(reject_data[0] == '>');
     // Fixture must stay LF-only; a Windows CRLF checkout makes indexOf('\\n')-1 count the '\\r'.
-    try std.testing.expect(std.mem.indexOfScalar(u8, reject_data, '\r') == null);
-    try std.testing.expectEqual(main.indexer.max_index_name_len + 1, std.mem.indexOfScalar(u8, reject_data, '\n').? - 1);
+    try std.testing.expect(std.mem.findScalar(u8, reject_data, '\r') == null);
+    try std.testing.expectEqual(main.indexer.MAX_INDEX_NAME_LEN + 1, std.mem.findScalar(u8, reject_data, '\n').? - 1);
     try std.testing.expectError(error.HeaderTooLong, main.indexer.scanZfiData(reject_data, true, allocator));
 }
 
@@ -3007,32 +2953,6 @@ test "gates fixture: zero geometry and large offset FAI rejected" {
     try expectCorruptFaiFixture(allocator, "tests/data/gates/seq1_large_offset");
 }
 
-fn expectCorruptFaiFixture(allocator: std.mem.Allocator, stem: []const u8) !void {
-    const src_fa = try std.fmt.allocPrint(allocator, "{s}.fasta", .{stem});
-    const src_fai = try std.fmt.allocPrint(allocator, "{s}.fasta.fai", .{stem});
-    const fasta_data = try readTestFile(allocator, src_fa);
-    defer allocator.free(fasta_data);
-    const fai_data = try readTestFile(allocator, src_fai);
-    defer allocator.free(fai_data);
-
-    const fasta_path = try uniqueArtifactPath(allocator, "gates-fai", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
-    {
-        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
-        defer fai_file.close(io);
-        try std.Io.File.writeStreamingAll(fai_file, io, fai_data);
-    }
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
-}
-
 test "gates fixture: zfi zero geometry from stable seq1 FASTA rejected" {
     try requireFixturePath("tests/data/gates/seq1_zero_geometry.fasta");
     const fasta_data = try readTestFile(std.testing.allocator, "tests/data/gates/seq1_zero_geometry.fasta");
@@ -3056,38 +2976,5 @@ test "gates fixture: zfi zero geometry from stable seq1 FASTA rejected" {
     defer index.deinit(allocator);
     index.records.items[0].line_bases = 0;
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
-    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(io, fasta_path));
-}
-
-test "NameDedup identity holds under forced hash collisions (P0 injectable check)" {
-    // Injectable hasher: every key lands in one bucket. NameDedupWith.observe must still
-    // keep distinct names via Context.eql (same code path as production NameDedup).
-    const CollisionCtx = struct {
-        pub fn hash(_: @This(), _: []const u8) u64 {
-            return 0xC0FFEE;
-        }
-        pub fn eql(_: @This(), a: []const u8, b: []const u8) bool {
-            return std.mem.eql(u8, a, b);
-        }
-    };
-
-    const CollidingDedup = main.indexer.NameDedupWith(CollisionCtx);
-    var seen = CollidingDedup.init(std.testing.allocator);
-    defer seen.deinit();
-
-    const names = [_][]const u8{ "alpha", "beta", "alpha", "gamma", "beta" };
-    var kept: usize = 0;
-    for (names) |name| {
-        if (!(try seen.observe(name))) kept += 1;
-    }
-    try std.testing.expectEqual(@as(usize, 3), kept);
-    try std.testing.expectEqual(@as(usize, 3), seen.map.count());
-
-    var prod = main.indexer.NameDedup.init(std.testing.allocator);
-    defer prod.deinit();
-    var prod_kept: usize = 0;
-    for (names) |name| {
-        if (!(try prod.observe(name))) prod_kept += 1;
-    }
-    try std.testing.expectEqual(kept, prod_kept);
+    try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
 }

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -410,7 +410,7 @@ test "[cli] - [index]: rejects multiple and nonexistent FASTA paths" {
     );
 }
 
-test "[cli] - [index]: writes ZFI and applies duplicate-name policy" {
+test "[cli] - [index]: atomically replaces ZFI and applies duplicate-name policy" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -420,7 +420,8 @@ test "[cli] - [index]: writes ZFI and applies duplicate-name policy" {
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{zfi_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
+    defer std.Io.Dir.cwd().deleteTree(io, tmp_path) catch {};
+    try std.Io.Dir.cwd().createDir(io, tmp_path, .default_dir);
     const dedup_message = try std.fmt.allocPrint(allocator, "wrote {s} (1 sequences)\n", .{zfi_path});
     try expectCliResult(allocator, &.{ ZFASTA_BIN, "index", fasta_path }, 0, "", dedup_message);
     {
@@ -439,7 +440,7 @@ test "[cli] - [index]: writes ZFI and applies duplicate-name policy" {
         try std.testing.expectEqual(@as(u64, 1), idx.records[0].seq_len);
         try std.testing.expectEqual(@as(u64, 2), idx.records[1].seq_len);
     }
-    try std.testing.expectError(error.FileNotFound, std.Io.Dir.cwd().access(io, tmp_path, .{}));
+    try std.Io.Dir.cwd().access(io, tmp_path, .{});
 }
 
 test "[unit] - [FASTA scanner]: records names and fixed-width geometry" {
@@ -604,6 +605,17 @@ test "[unit] - [ZFI format]: retains frozen wire sizes" {
     try std.testing.expectEqual(@as(usize, 16), @sizeOf(ZfiHeader));
     try std.testing.expectEqual(@as(usize, 40), @sizeOf(IndexRecord));
     try std.testing.expectEqual(@as(usize, 32), @sizeOf(main.index_format.SideTableLine));
+}
+
+test "[failure] - [ZFI source identity]: rejects a pre-epoch timestamp" {
+    try std.testing.expectEqual(
+        @as(u64, 0),
+        try main.index_format.timestampToNs(std.Io.Timestamp.fromNanoseconds(0)),
+    );
+    try std.testing.expectError(
+        error.TimestampOutOfRange,
+        main.index_format.timestampToNs(std.Io.Timestamp.fromNanoseconds(-1)),
+    );
 }
 
 test "[property] - [ZFI format]: encoders match the frozen little-endian layout" {
@@ -1345,12 +1357,14 @@ test "[failure] - [ZFI loader]: rejects malformed side-table lines" {
     const Mutation = enum {
         broken_base_prefix,
         repeated_byte_offset,
+        overlapping_line_span,
         line_past_fasta,
         wrong_base_total,
     };
     const cases = [_]Mutation{
         .broken_base_prefix,
         .repeated_byte_offset,
+        .overlapping_line_span,
         .line_past_fasta,
         .wrong_base_total,
     };
@@ -1369,6 +1383,11 @@ test "[failure] - [ZFI loader]: rejects malformed side-table lines" {
             .repeated_byte_offset => {
                 const first_offset = std.mem.readInt(u64, zfi_bytes[first_line + 8 ..][0..8], .little);
                 std.mem.writeInt(u64, zfi_bytes[second_line + 8 ..][0..8], first_offset, .little);
+            },
+            .overlapping_line_span => {
+                const first_offset = std.mem.readInt(u64, zfi_bytes[first_line + 8 ..][0..8], .little);
+                const first_bytes = std.mem.readInt(u64, zfi_bytes[first_line + 16 ..][0..8], .little);
+                std.mem.writeInt(u64, zfi_bytes[second_line + 8 ..][0..8], first_offset + first_bytes - 1, .little);
             },
             .line_past_fasta => std.mem.writeInt(u64, zfi_bytes[first_line + 16 ..][0..8], fasta_data.len + 1, .little),
             .wrong_base_total => {
@@ -1967,9 +1986,9 @@ test "[failure] - [FAI loader]: rejects names above the u16 limit" {
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    var fai_buf: std.ArrayListUnmanaged(u8) = .empty;
+    var fai_buf: std.ArrayList(u8) = .empty;
     defer fai_buf.deinit(allocator);
-    try fai_buf.appendNTimes(allocator, 'N', 65536);
+    try fai_buf.appendNTimes(allocator, 'N', 65_600);
     try fai_buf.appendSlice(allocator, "\t4\t6\t4\t5\n");
 
     const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
@@ -1977,6 +1996,19 @@ test "[failure] - [FAI loader]: rejects names above the u16 limit" {
     try std.Io.File.writeStreamingAll(fai_file, io, fai_buf.items);
 
     try std.testing.expectError(error.CorruptIndex, loadIndexChecked(std.testing.allocator, io, fasta_path));
+    try std.testing.expectError(
+        error.CorruptIndex,
+        main.index_format.loadIndexCheckedWithMode(
+            std.testing.allocator,
+            io,
+            fasta_path,
+            .{ .positional = &.{"seq1"} },
+        ),
+    );
+    try std.testing.expectError(
+        error.CorruptIndex,
+        main.index_format.loadIndexCheckedWithMode(std.testing.allocator, io, fasta_path, .stats_scan),
+    );
 }
 
 test "[edge] - [FAI loader]: streamed modes accept the maximum sequence name" {

--- a/tests/test_index.zig
+++ b/tests/test_index.zig
@@ -12,6 +12,9 @@ const expectCliFailure = utility.expectCliFailure;
 const expectCliResult = utility.expectCliResult;
 const expectUnknownOptionRejected = utility.expectUnknownOptionRejected;
 const uniqueArtifactPath = utility.uniqueArtifactPath;
+const readTestFile = utility.readRequiredFile;
+const writeFastaArtifact = utility.writeFastaArtifact;
+const statMtimeNs = utility.statMtimeNs;
 const scanFaiData = main.indexer.scanFaiData;
 const INDEX_READ_BUFFER_SIZE = main.indexer.INDEX_READ_BUFFER_SIZE;
 const IndexRecord = main.index_format.IndexRecord;
@@ -29,27 +32,15 @@ fn loadAndDeinitForAllocationCheck(allocator: std.mem.Allocator, fasta_path: []c
     defer idx.deinit();
 }
 
-fn statMtimeNs(path: []const u8) !u64 {
-    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
-    defer file.close(io);
-    const st = try file.stat(io);
-    return main.index_format.timestampToNs(st.mtime);
-}
-
 // Patch a raw `.zfi` source identity so malformed-index tests reach structural checks.
 fn writeFastaAndRawZfi(allocator: std.mem.Allocator, stem: []const u8, fasta: []const u8, zfi_bytes: []const u8) !struct { fasta_path: []u8, zfi_path: []u8 } {
-    const fasta_path = try uniqueArtifactPath(allocator, stem, "fa");
+    const fasta_path = try writeFastaArtifact(allocator, stem, fasta);
     errdefer allocator.free(fasta_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     errdefer allocator.free(zfi_path);
-    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     errdefer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta);
-    }
     // Re-open for mtime: Windows `stat` on the create handle can return AccessDenied.
     const fasta_mtime = try statMtimeNs(fasta_path);
 
@@ -72,18 +63,13 @@ fn writeFastaAndRawZfi(allocator: std.mem.Allocator, stem: []const u8, fasta: []
 }
 
 fn writeFastaAndFai(allocator: std.mem.Allocator, stem: []const u8, fasta: []const u8, fai: []const u8) !struct { fasta_path: []u8, fai_path: []u8 } {
-    const fasta_path = try uniqueArtifactPath(allocator, stem, "fa");
+    const fasta_path = try writeFastaArtifact(allocator, stem, fasta);
     errdefer allocator.free(fasta_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     errdefer allocator.free(fai_path);
-    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     errdefer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta);
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
         defer fai_file.close(io);
@@ -100,10 +86,7 @@ fn supportsPosixFutimens() bool {
 }
 
 fn uniqueArtifactDirPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
-    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    const path = try std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}", .{ stem, nanos });
+    const path = try uniqueArtifactPath(allocator, stem, "dir");
     errdefer allocator.free(path);
     try std.Io.Dir.cwd().createDirPath(io, path);
     return path;
@@ -150,24 +133,6 @@ fn markFileStaleOneHourAgo(file: std.Io.File) !void {
         },
         else => return error.SkipZigTest,
     }
-}
-
-fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
-        error.FileNotFound => {
-            std.debug.print("required test fixture missing: {s}\n", .{path});
-            return error.RequiredFixtureMissing;
-        },
-        else => |e| return e,
-    };
-    defer file.close(io);
-    const stat = try file.stat(io);
-    const size = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
-    const data = try allocator.alloc(u8, size);
-    errdefer allocator.free(data);
-    const bytes_read = try std.Io.File.readPositionalAll(file, io, data, 0);
-    if (bytes_read != data.len) return error.UnexpectedEndOfFile;
-    return data;
 }
 
 fn scanRecordsForTest(allocator: std.mem.Allocator, data: []const u8) !std.ArrayList(IndexRecord) {
@@ -450,18 +415,12 @@ test "[cli] - [index]: writes ZFI and applies duplicate-name policy" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "index-cli-success", "fa");
+    const fasta_path = try writeFastaArtifact(allocator, "index-cli-success", ">dup\nA\n>dup\nCC\n");
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const tmp_path = try std.fmt.allocPrint(allocator, "{s}.tmp", .{zfi_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, tmp_path) catch {};
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">dup\nA\n>dup\nCC\n");
-    }
-
     const dedup_message = try std.fmt.allocPrint(allocator, "wrote {s} (1 sequences)\n", .{zfi_path});
     try expectCliResult(allocator, &.{ ZFASTA_BIN, "index", fasta_path }, 0, "", dedup_message);
     {
@@ -1162,16 +1121,11 @@ test "[integration] - [FAI loader]: resolves an empty sequence name" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "empty-name-fai", "fa");
+    const fasta_path = try writeFastaArtifact(allocator, "empty-name-fai", data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, data);
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
         defer fai_file.close(io);
@@ -1211,16 +1165,13 @@ test "[failure] - [ZFI loader]: rejects record names outside the name blob" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "corrupt-zfi", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const fasta_data = ">seq1\nACGT\n";
+    const fasta_path = try writeFastaArtifact(allocator, "corrupt-zfi", fasta_data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
-
-    var index = try main.indexer.scanZfiData(">seq1\nACGT\n", true, allocator);
+    var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
     index.records.items[0].name_offset = 999_999;
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, 11, try statMtimeNs(fasta_path));
@@ -1233,15 +1184,11 @@ test "[failure] - [ZFI loader]: rejects a sequence offset at EOF" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "past-end-zfi", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
     const fasta_data = ">seq1\nACGT\n";
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
+    const fasta_path = try writeFastaArtifact(allocator, "past-end-zfi", fasta_data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
@@ -1541,16 +1488,11 @@ test "[failure] - [index loaders]: release partial allocations" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-    const fasta_path = try uniqueArtifactPath(allocator, "fai-allocation-failures", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "fai-allocation-failures", ">a\nAAAA\n>b\nCC\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">a\nAAAA\n>b\nCC\n");
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
         defer fai_file.close(io);
@@ -1569,15 +1511,11 @@ test "[property] - [ZFI loader]: modes select the first duplicate" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "duplicate-zfi", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
     const fasta_data = ">dup\nAAAA\n>dup\nCCCCCC\n";
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
+    const fasta_path = try writeFastaArtifact(allocator, "duplicate-zfi", fasta_data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     var index = try main.indexer.scanZfiData(fasta_data, false, allocator);
     defer index.deinit(allocator);
@@ -1598,18 +1536,13 @@ test "[integration] - [index loader]: gives a present ZFI authority over FAI" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "stale-zfi", "fa");
+    const fasta_data = ">seq1\nACGTACGT\n>seq2\nGGGG\n";
+    const fasta_path = try writeFastaArtifact(allocator, "stale-zfi", fasta_data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_data = ">seq1\nACGTACGT\n>seq2\nGGGG\n";
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{ .truncate = true });
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
 
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
@@ -1640,18 +1573,13 @@ test "[failure] - [index loader]: rejects an invalid present ZFI despite valid F
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "invalid-zfi-authority", "fa");
+    const fasta_path = try writeFastaArtifact(allocator, "invalid-zfi-authority", ">seq\nACGT\n");
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
         defer fai_file.close(io);
@@ -1681,18 +1609,13 @@ test "[failure] - [index loader]: reports an inaccessible selected sidecar" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "inaccessible-sidecar", "fa");
+    const fasta_path = try writeFastaArtifact(allocator, "inaccessible-sidecar", ">seq\nACGT\n");
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
     {
         const zfi_file = try std.Io.Dir.cwd().createFile(io, zfi_path, .{});
         defer zfi_file.close(io);
@@ -1730,15 +1653,11 @@ test "[property] - [FAI loader]: modes select the first duplicate" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "duplicate-fai", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
     const fasta_data = ">dup\nAAAA\n>dup\nCCCCCC\n";
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
+    const fasta_path = try writeFastaArtifact(allocator, "duplicate-fai", fasta_data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
     const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
     defer fai_file.close(io);
@@ -1763,20 +1682,15 @@ test "[integration] - [FAI loader]: positional mode retains first matches and va
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "positional-fai", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(
+        allocator,
+        "positional-fai",
+        ">wanted\nAAAA\n>wanted\nCCCCCC\n>colon:name\nGGGG\n>\nTT\n>other\nAC\n",
+    );
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(
-            fasta_file,
-            io,
-            ">wanted\nAAAA\n>wanted\nCCCCCC\n>colon:name\nGGGG\n>\nTT\n>other\nAC\n",
-        );
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
         defer fai_file.close(io);
@@ -1835,16 +1749,11 @@ test "[unit] - [FAI loader]: full lookup borrows mapped names" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "borrowed-fai-name", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "borrowed-fai-name", ">seq\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
         defer fai_file.close(io);
@@ -1867,16 +1776,11 @@ test "[integration] - [FAI loader]: positional mode retains the FASTA descriptor
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "fai-source-descriptor", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "fai-source-descriptor", ">seq\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
         defer fai_file.close(io);
@@ -1905,16 +1809,11 @@ test "[integration] - [get index loader]: keeps FASTA readable without mapping i
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "fai-get-source", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "fai-get-source", ">seq\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
     {
         const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
         defer fai_file.close(io);
@@ -2023,14 +1922,10 @@ test "[failure] - [FAI loader]: positional mode rejects impossible geometry" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-positional", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "bad-fai-positional", ">seq1\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
 
     const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
     defer fai_file.close(io);
@@ -2047,14 +1942,10 @@ test "[failure] - [FAI loader]: stats mode rejects impossible geometry" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-stats-scan", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "bad-fai-stats-scan", ">seq1\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
 
     const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{ .truncate = true });
     defer fai_file.close(io);
@@ -2071,14 +1962,10 @@ test "[failure] - [FAI loader]: rejects names above the u16 limit" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "bad-fai-long-name", "fa");
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "bad-fai-long-name", ">seq1\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
-
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, ">seq1\nACGT\n");
 
     var fai_buf: std.ArrayListUnmanaged(u8) = .empty;
     defer fai_buf.deinit(allocator);
@@ -2180,15 +2067,11 @@ test "[edge] - [ZFI loader]: accepts FASTA without a terminal newline" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "zfi-fasta-no-term-nl", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
     const fasta_data = ">seq1\nACGT";
-    const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
+    const fasta_path = try writeFastaArtifact(allocator, "zfi-fasta-no-term-nl", fasta_data);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
@@ -2302,16 +2185,14 @@ test "[failure] - [FAI workflow]: leaves output and spool empty" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "fai-nonuniform-spool", "fa");
+    const fasta_path = try writeFastaArtifact(
+        allocator,
+        "fai-nonuniform-spool",
+        ">mixed\nAAAA\nBBBBBB\nCC\n",
+    );
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
     const spool_dir_path = try uniqueArtifactDirPath(allocator, "fai-spool-failure");
     defer std.Io.Dir.cwd().deleteTree(io, spool_dir_path) catch {};
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">mixed\nAAAA\nBBBBBB\nCC\n");
-    }
-
     var env = try std.testing.environ.createMap(allocator);
     defer env.deinit();
     try env.put("TMPDIR", "zig-cache/test-artifacts/definitely-missing-spool");
@@ -2346,17 +2227,12 @@ test "[failure] - [ZFI loader]: rejects a source size change" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "stale-size", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const fasta_data = ">seq1\nACGT\n";
+    const fasta_path = try writeFastaArtifact(allocator, "stale-size", fasta_data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    const fasta_data = ">seq1\nACGT\n";
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
     try main.indexer.writeZfiIndexFile(io, zfi_path, &index, fasta_data.len, try statMtimeNs(fasta_path));
@@ -2375,20 +2251,14 @@ test "[failure] - [ZFI loader]: rejects a same-size source replacement" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "stale-same-size", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
     const fasta_a = ">seq1\nACGT\n";
     const fasta_b = ">seq1\nTTTT\n";
-    try std.testing.expectEqual(fasta_a.len, fasta_b.len);
+    const fasta_path = try writeFastaArtifact(allocator, "stale-same-size", fasta_a);
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_a);
-    }
+    try std.testing.expectEqual(fasta_a.len, fasta_b.len);
     const mtime_a = try statMtimeNs(fasta_path);
     var index = try main.indexer.scanZfiData(fasta_a, true, allocator);
     defer index.deinit(allocator);
@@ -2485,16 +2355,11 @@ test "[failure] - [ZFI loader]: rejects mismatched embedded source time" {
     const allocator = arena.allocator();
 
     const fasta_data = ">seq1\nACGT\n";
-    const fasta_path = try uniqueArtifactPath(allocator, "zfi-bad-mtime", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "zfi-bad-mtime", fasta_data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
     const real_mtime = try statMtimeNs(fasta_path);
     const wrong_mtime = real_mtime +% 1;
 
@@ -2535,16 +2400,11 @@ test "[failure] - [ZFI loader]: rejects zero line geometry" {
     const allocator = arena.allocator();
 
     const fasta_data = ">seq1\nACGT\n";
-    const fasta_path = try uniqueArtifactPath(allocator, "zfi-zero-geom", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "zfi-zero-geom", fasta_data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
     index.records.items[0].line_bases = 0;
@@ -2936,16 +2796,11 @@ test "[integration] - [index gates]: reject zero ZFI geometry" {
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta_path = try uniqueArtifactPath(allocator, "gates-zfi-zero", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    const fasta_path = try writeFastaArtifact(allocator, "gates-zfi-zero", fasta_data);
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, fasta_data);
-    }
     var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
     defer index.deinit(allocator);
     index.records.items[0].line_bases = 0;

--- a/tests/test_stats.zig
+++ b/tests/test_stats.zig
@@ -307,7 +307,7 @@ test "[integration] - [stats report]: ZFI and FAI render identical mixed nucleot
             zfi_path,
             &index,
             fasta_data.len,
-            main.index_format.timestampToNs(fasta_stat.mtime),
+            try main.index_format.timestampToNs(fasta_stat.mtime),
         );
     }
 

--- a/tests/test_stats.zig
+++ b/tests/test_stats.zig
@@ -1,4 +1,4 @@
-//! Stats unit and CLI tests: type detection and exact report behavior.
+//! Stats tests: type detection, exact reports, index parity, and CLI failures.
 //!
 //! Exercises complete stats output against fixture FASTAs.
 
@@ -24,23 +24,67 @@ fn runStatsAndCapture(allocator: std.mem.Allocator, fasta_path: []const u8) ![]u
 
     const result = try std.process.run(allocator, threaded.io(), .{
         .argv = &.{ ZFASTA_BIN, "stats", fasta_path },
-        .stdout_limit = .limited(10 * 1024 * 1024),
+        .stdout_limit = .limited(64 * 1024),
         .stderr_limit = .limited(64 * 1024),
     });
     errdefer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 
     switch (result.term) {
-        .exited => |code| if (code != 0) return error.ChildProcessFailed,
+        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
         else => return error.ChildProcessFailed,
     }
-    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
+    try std.testing.expectEqualStrings("", result.stderr);
     return result.stdout;
+}
+
+fn writeSingleLineFaiFixture(
+    allocator: std.mem.Allocator,
+    stem: []const u8,
+    name: []const u8,
+    sequence: []const u8,
+) !struct { fasta_path: []u8, fai_path: []u8 } {
+    const fasta_path = try utility.uniqueArtifactPath(allocator, stem, "fa");
+    errdefer allocator.free(fasta_path);
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta_path});
+    errdefer allocator.free(fai_path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    errdefer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, ">");
+        try std.Io.File.writeStreamingAll(fasta_file, io, name);
+        try std.Io.File.writeStreamingAll(fasta_file, io, "\n");
+        try std.Io.File.writeStreamingAll(fasta_file, io, sequence);
+        try std.Io.File.writeStreamingAll(fasta_file, io, "\n");
+    }
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
+        defer fai_file.close(io);
+        var buffer: [128]u8 = undefined;
+        var writer = fai_file.writer(io, &buffer);
+        try writer.interface.print("{s}\t{d}\t{d}\t{d}\t{d}\n", .{
+            name,
+            sequence.len,
+            name.len + 2,
+            sequence.len,
+            sequence.len + 1,
+        });
+        try writer.interface.flush();
+    }
+    return .{ .fasta_path = fasta_path, .fai_path = fai_path };
+}
+
+fn expectComposition(expected: []const u8, report: []const u8) !void {
+    const start = std.mem.indexOf(u8, report, "Composition:\n") orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings(expected, report[start..]);
 }
 
 // --- Type detection ---
 
-test "detectType classifies representative alphabets" {
+test "[unit] - [sequence type]: classifies representative alphabets" {
     const Case = struct {
         symbols: []const u8,
         expected: stats.SequenceType,
@@ -60,7 +104,7 @@ test "detectType classifies representative alphabets" {
     }
 }
 
-test "detectType uses a strict overflow-safe 90 percent boundary" {
+test "[edge] - [sequence type]: uses a strict overflow-safe 90 percent boundary" {
     const Case = struct {
         total: u64,
         nucleotide: u64,
@@ -93,10 +137,10 @@ test "detectType uses a strict overflow-safe 90 percent boundary" {
     }
 }
 
-test "detectType matches its threshold across deterministic fuzzy inputs" {
+test "[property] - [sequence type]: matches the threshold across generated counts" {
     const nucleotide_codes = "ACGTURYSWKMBDHVNacgturyswkmbdhvn";
     const protein_only_codes = "EFLPQXZJO*eflpqxzjo*";
-    var prng = std.Random.DefaultPrng.init(0x7a_fa_57_a7_5);
+    var prng = std.Random.DefaultPrng.init(std.testing.random_seed);
     const random = prng.random();
 
     for (0..4096) |i| {
@@ -110,7 +154,13 @@ test "detectType matches its threshold across deterministic fuzzy inputs" {
         else
             .protein;
 
-        try std.testing.expectEqual(expected, stats.detectType(&counts, total));
+        std.testing.expectEqual(expected, stats.detectType(&counts, total)) catch {
+            std.debug.print(
+                "sequence type mismatch: seed={d}, iteration={d}, total={d}, nucleotide={d}\n",
+                .{ std.testing.random_seed, i, total, nucleotide },
+            );
+            return error.TestExpectedEqual;
+        };
     }
 }
 
@@ -152,39 +202,34 @@ test "[cli] - [stats]: rejects invalid FASTA path counts" {
     );
 }
 
-test "[cli] - [stats index selection]: invalid zfi blocks a valid fai" {
+test "[cli] - [stats]: reports missing and corrupt indexes" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const fasta = try utility.uniqueArtifactPath(allocator, "stats-invalid-zfi", "fa");
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
-    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta});
+    const fasta = try utility.writeFastaArtifact(allocator, "stats-index-errors", ">seq\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
     defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
 
-    {
-        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta, .{});
-        defer fasta_file.close(io);
-        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
-    }
-    {
-        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
-        defer fai_file.close(io);
-        try std.Io.File.writeStreamingAll(fai_file, io, "seq\t4\t5\t4\t5\n");
-    }
+    const missing = try std.fmt.allocPrint(
+        allocator,
+        "error: no index found for {s}. Run 'z-fasta index {s}' first.\n",
+        .{ fasta, fasta },
+    );
+    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", fasta }, 1, missing);
+
     {
         const zfi_file = try std.Io.Dir.cwd().createFile(io, zfi_path, .{});
         defer zfi_file.close(io);
         try std.Io.File.writeStreamingAll(zfi_file, io, "not a zfi index");
     }
 
-    const expected = try std.fmt.allocPrint(allocator, "error: corrupt index file for: {s}\n", .{fasta});
-    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", fasta }, 1, expected);
+    const corrupt = try std.fmt.allocPrint(allocator, "error: corrupt index file for: {s}\n", .{fasta});
+    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", fasta }, 1, corrupt);
 }
 
-test "stats renders the exact nucleotide report" {
+test "[cli] - [stats report]: renders the exact nucleotide report" {
     const expected =
         \\File:
         \\  path: tests/data/simple.fasta
@@ -234,7 +279,150 @@ test "stats renders the exact nucleotide report" {
     try std.testing.expectEqualStrings(expected, output);
 }
 
-test "stats renders the exact protein report" {
+test "[integration] - [stats report]: ZFI and FAI render identical mixed nucleotide statistics" {
+    const fasta_data = ">mixed\nacgtuACGTURYSWKMBDHVN?\n";
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const paths = try writeSingleLineFaiFixture(
+        allocator,
+        "stats-index-parity",
+        "mixed",
+        "acgtuACGTURYSWKMBDHVN?",
+    );
+    const fasta_path = paths.fasta_path;
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta_path});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+    {
+        const fasta_file = try std.Io.Dir.cwd().openFile(io, fasta_path, .{});
+        defer fasta_file.close(io);
+        const fasta_stat = try fasta_file.stat(io);
+        var index = try main.indexer.scanZfiData(fasta_data, true, allocator);
+        defer index.deinit(allocator);
+        try main.indexer.writeZfiIndexFile(
+            io,
+            zfi_path,
+            &index,
+            fasta_data.len,
+            main.index_format.timestampToNs(fasta_stat.mtime),
+        );
+    }
+
+    const expected_composition =
+        \\Composition:
+        \\  type: nucleotide_mixed_tu
+        \\  percent_denominator: total_symbols
+        \\  a: 2 9.09%
+        \\  c: 2 9.09%
+        \\  g: 2 9.09%
+        \\  t: 2 9.09%
+        \\  u: 2 9.09%
+        \\  n: 1 4.55%
+        \\  iupac_ambiguous: 10 45.45%
+        \\  invalid: 1 4.55%
+        \\  gc: 40.00%
+        \\  gc_skew: 0.000
+        \\  lowercase: 5 22.73%
+        \\
+    ;
+
+    const zfi_output = try runStatsAndCapture(allocator, fasta_path);
+    defer allocator.free(zfi_output);
+    try expectComposition(expected_composition, zfi_output);
+
+    try std.Io.Dir.cwd().deleteFile(io, zfi_path);
+    const fai_output = try runStatsAndCapture(allocator, fasta_path);
+    defer allocator.free(fai_output);
+    try expectComposition(expected_composition, fai_output);
+
+    const zfi_index = try std.fmt.allocPrint(allocator, "  index: {s}.zfi\n", .{fasta_path});
+    const fai_index = try std.fmt.allocPrint(allocator, "  index: {s}.fai\n", .{fasta_path});
+    const zfi_index_start = std.mem.indexOf(u8, zfi_output, zfi_index) orelse return error.TestExpectedEqual;
+    const fai_index_start = std.mem.indexOf(u8, fai_output, fai_index) orelse return error.TestExpectedEqual;
+    try std.testing.expectEqualStrings(zfi_output[0..zfi_index_start], fai_output[0..fai_index_start]);
+    try std.testing.expectEqualStrings(
+        zfi_output[zfi_index_start + zfi_index.len ..],
+        fai_output[fai_index_start + fai_index.len ..],
+    );
+}
+
+test "[cli] - [stats report]: renders RNA and ambiguity-only nucleotide variants" {
+    const Case = struct {
+        stem: []const u8,
+        name: []const u8,
+        sequence: []const u8,
+        composition: []const u8,
+    };
+    const cases = [_]Case{
+        .{
+            .stem = "stats-rna",
+            .name = "rna",
+            .sequence = "ACcuUU",
+            .composition =
+            \\Composition:
+            \\  type: nucleotide_u
+            \\  percent_denominator: total_symbols
+            \\  a: 1 16.67%
+            \\  c: 2 33.33%
+            \\  g: 0 0.00%
+            \\  t: 0 0.00%
+            \\  u: 3 50.00%
+            \\  n: 0 0.00%
+            \\  iupac_ambiguous: 0 0.00%
+            \\  invalid: 0 0.00%
+            \\  gc: 33.33%
+            \\  gc_skew: -1.000
+            \\  lowercase: 2 33.33%
+            \\
+            ,
+        },
+        .{
+            .stem = "stats-ambiguity",
+            .name = "ambiguity",
+            .sequence = "RYSWKMBDHVNN",
+            .composition =
+            \\Composition:
+            \\  type: nucleotide
+            \\  percent_denominator: total_symbols
+            \\  a: 0 0.00%
+            \\  c: 0 0.00%
+            \\  g: 0 0.00%
+            \\  t: 0 0.00%
+            \\  u: 0 0.00%
+            \\  n: 2 16.67%
+            \\  iupac_ambiguous: 10 83.33%
+            \\  invalid: 0 0.00%
+            \\  gc: n/a
+            \\  gc_skew: n/a
+            \\  lowercase: 0 0.00%
+            \\
+            ,
+        },
+    };
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    for (cases) |case| {
+        const paths = try writeSingleLineFaiFixture(
+            allocator,
+            case.stem,
+            case.name,
+            case.sequence,
+        );
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+        defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+
+        const output = try runStatsAndCapture(allocator, paths.fasta_path);
+        defer allocator.free(output);
+        try expectComposition(case.composition, output);
+    }
+}
+
+test "[cli] - [stats report]: renders the exact protein report" {
     const expected =
         \\File:
         \\  path: tests/data/proteome.fasta
@@ -300,4 +488,59 @@ test "stats renders the exact protein report" {
     defer std.testing.allocator.free(output);
 
     try std.testing.expectEqualStrings(expected, output);
+}
+
+test "[cli] - [stats report]: counts the complete protein alphabet and exceptional symbols" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const paths = try writeSingleLineFaiFixture(
+        allocator,
+        "stats-protein-categories",
+        "protein",
+        "ARNDCEQGHILKMFPSTWYVBZJXUOar*?",
+    );
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fasta_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, paths.fai_path) catch {};
+
+    const expected =
+        \\Composition:
+        \\  type: protein
+        \\  percent_denominator: total_symbols
+        \\  a_alanine: 2 6.67%
+        \\  r_arginine: 2 6.67%
+        \\  n_asparagine: 1 3.33%
+        \\  d_aspartate: 1 3.33%
+        \\  c_cysteine: 1 3.33%
+        \\  e_glutamate: 1 3.33%
+        \\  q_glutamine: 1 3.33%
+        \\  g_glycine: 1 3.33%
+        \\  h_histidine: 1 3.33%
+        \\  i_isoleucine: 1 3.33%
+        \\  l_leucine: 1 3.33%
+        \\  k_lysine: 1 3.33%
+        \\  m_methionine: 1 3.33%
+        \\  f_phenylalanine: 1 3.33%
+        \\  p_proline: 1 3.33%
+        \\  s_serine: 1 3.33%
+        \\  t_threonine: 1 3.33%
+        \\  w_tryptophan: 1 3.33%
+        \\  y_tyrosine: 1 3.33%
+        \\  v_valine: 1 3.33%
+        \\  b_asx: 1 3.33%
+        \\  z_glx: 1 3.33%
+        \\  j_xle: 1 3.33%
+        \\  x_unknown: 1 3.33%
+        \\  u_selenocysteine: 1 3.33%
+        \\  o_pyrrolysine: 1 3.33%
+        \\  stop: 1 3.33%
+        \\  invalid: 1 3.33%
+        \\  lowercase: 2 6.67%
+        \\
+    ;
+
+    const output = try runStatsAndCapture(allocator, paths.fasta_path);
+    defer allocator.free(output);
+    try expectComposition(expected, output);
 }

--- a/tests/test_stats.zig
+++ b/tests/test_stats.zig
@@ -5,10 +5,9 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const main = @import("main");
-const detectType = main.stats.detectType;
-const SequenceType = main.stats.SequenceType;
+const stats = main.stats;
 
-// --- Type detection ---
+const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
 
 fn countSymbols(symbols: []const u8) [256]u64 {
     var counts: [256]u64 = .{0} ** 256;
@@ -16,10 +15,32 @@ fn countSymbols(symbols: []const u8) [256]u64 {
     return counts;
 }
 
+fn runStatsAndCapture(allocator: std.mem.Allocator, fasta_path: []const u8) ![]u8 {
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+
+    const result = try std.process.run(allocator, threaded.io(), .{
+        .argv = &.{ ZFASTA_BIN, "stats", fasta_path },
+        .stdout_limit = .limited(10 * 1024 * 1024),
+        .stderr_limit = .limited(64 * 1024),
+    });
+    errdefer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| if (code != 0) return error.ChildProcessFailed,
+        else => return error.ChildProcessFailed,
+    }
+    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
+    return result.stdout;
+}
+
+// --- Type detection ---
+
 test "detectType classifies representative alphabets" {
     const Case = struct {
         symbols: []const u8,
-        expected: SequenceType,
+        expected: stats.SequenceType,
     };
     const cases = [_]Case{
         .{ .symbols = "", .expected = .nucleotide },
@@ -32,7 +53,7 @@ test "detectType classifies representative alphabets" {
     for (cases) |case| {
         const counts = countSymbols(case.symbols);
 
-        try std.testing.expectEqual(case.expected, detectType(&counts, case.symbols.len));
+        try std.testing.expectEqual(case.expected, stats.detectType(&counts, case.symbols.len));
     }
 }
 
@@ -40,7 +61,7 @@ test "detectType uses a strict overflow-safe 90 percent boundary" {
     const Case = struct {
         total: u64,
         nucleotide: u64,
-        expected: SequenceType,
+        expected: stats.SequenceType,
     };
     const cases = [_]Case{
         .{ .total = 10, .nucleotide = 9, .expected = .protein },
@@ -65,7 +86,7 @@ test "detectType uses a strict overflow-safe 90 percent boundary" {
         counts['A'] = case.nucleotide;
         counts['L'] = case.total - case.nucleotide;
 
-        try std.testing.expectEqual(case.expected, detectType(&counts, case.total));
+        try std.testing.expectEqual(case.expected, stats.detectType(&counts, case.total));
     }
 }
 
@@ -81,44 +102,18 @@ test "detectType matches its threshold across deterministic fuzzy inputs" {
         var counts: [256]u64 = .{0} ** 256;
         counts[nucleotide_codes[i % nucleotide_codes.len]] = nucleotide;
         counts[protein_only_codes[i % protein_only_codes.len]] = total - nucleotide;
-        const expected: SequenceType = if (@as(u128, nucleotide) * 10 > @as(u128, total) * 9)
+        const expected: stats.SequenceType = if (@as(u128, nucleotide) * 10 > @as(u128, total) * 9)
             .nucleotide
         else
             .protein;
 
-        try std.testing.expectEqual(expected, detectType(&counts, total));
+        try std.testing.expectEqual(expected, stats.detectType(&counts, total));
     }
 }
 
 // --- CLI reports ---
 
-const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
-
-fn runStatsAndCapture(allocator: std.mem.Allocator, fasta_path: []const u8) ![]u8 {
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const io = threaded.io();
-
-    var proc = try std.process.spawn(io, .{
-        .argv = &.{ ZFASTA_BIN, "stats", fasta_path },
-        .stdout = .pipe,
-    });
-    errdefer proc.kill(io);
-
-    var read_buf: [4096]u8 = undefined;
-    var stdout_reader = proc.stdout.?.reader(io, &read_buf);
-    const result = try stdout_reader.interface.allocRemaining(allocator, .limited(10 * 1024 * 1024));
-    switch (try proc.wait(io)) {
-        .exited => |code| if (code != 0) return error.ChildProcessFailed,
-        else => return error.ChildProcessFailed,
-    }
-    return result;
-}
-
 test "stats renders the exact nucleotide report" {
-    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/simple.fasta");
-    defer std.testing.allocator.free(output);
-
     const expected =
         \\File:
         \\  path: tests/data/simple.fasta
@@ -162,13 +157,13 @@ test "stats renders the exact nucleotide report" {
         \\
     ;
 
+    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/simple.fasta");
+    defer std.testing.allocator.free(output);
+
     try std.testing.expectEqualStrings(expected, output);
 }
 
 test "stats renders the exact protein report" {
-    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/proteome.fasta");
-    defer std.testing.allocator.free(output);
-
     const expected =
         \\File:
         \\  path: tests/data/proteome.fasta
@@ -229,5 +224,9 @@ test "stats renders the exact protein report" {
         \\  lowercase: 0 0.00%
         \\
     ;
+
+    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/proteome.fasta");
+    defer std.testing.allocator.free(output);
+
     try std.testing.expectEqualStrings(expected, output);
 }

--- a/tests/test_stats.zig
+++ b/tests/test_stats.zig
@@ -3,11 +3,14 @@
 //! Exercises complete stats output against fixture FASTAs.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const main = @import("main");
+const utility = @import("utility.zig");
 const stats = main.stats;
+const io = std.testing.io;
 
-const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+const ZFASTA_BIN = utility.ZFASTA_BIN;
+const expectCliFailure = utility.expectCliFailure;
+const expectUnknownOptionRejected = utility.expectUnknownOptionRejected;
 
 fn countSymbols(symbols: []const u8) [256]u64 {
     var counts: [256]u64 = .{0} ** 256;
@@ -112,6 +115,74 @@ test "detectType matches its threshold across deterministic fuzzy inputs" {
 }
 
 // --- CLI reports ---
+
+test "[cli] - [stats]: rejects unknown options regardless of position" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const fasta = "tests/data/simple.fasta";
+
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", "--not-a-flag", fasta }, "--not-a-flag");
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", fasta, "--not-a-flag" }, "--not-a-flag");
+    try expectUnknownOptionRejected(allocator, &.{ ZFASTA_BIN, "stats", "--index-only", fasta }, "--index-only");
+}
+
+test "[cli] - [stats]: rejects invalid FASTA path counts" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "stats" },
+        1,
+        "error: usage: z-fasta stats <file.fasta>\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "stats", "tests/data/simple.fasta", "tests/data/single.fasta" },
+        1,
+        "error: stats accepts exactly one FASTA path\n",
+    );
+    try expectCliFailure(
+        allocator,
+        &.{ ZFASTA_BIN, "stats", "tests/data/definitely-missing-cli-failure.fasta" },
+        1,
+        "error: file not found: tests/data/definitely-missing-cli-failure.fasta\n",
+    );
+}
+
+test "[cli] - [stats index selection]: invalid zfi blocks a valid fai" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const fasta = try utility.uniqueArtifactPath(allocator, "stats-invalid-zfi", "fa");
+    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fasta});
+    const fai_path = try std.fmt.allocPrint(allocator, "{s}.fai", .{fasta});
+    defer std.Io.Dir.cwd().deleteFile(io, fasta) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(io, fai_path) catch {};
+
+    {
+        const fasta_file = try std.Io.Dir.cwd().createFile(io, fasta, .{});
+        defer fasta_file.close(io);
+        try std.Io.File.writeStreamingAll(fasta_file, io, ">seq\nACGT\n");
+    }
+    {
+        const fai_file = try std.Io.Dir.cwd().createFile(io, fai_path, .{});
+        defer fai_file.close(io);
+        try std.Io.File.writeStreamingAll(fai_file, io, "seq\t4\t5\t4\t5\n");
+    }
+    {
+        const zfi_file = try std.Io.Dir.cwd().createFile(io, zfi_path, .{});
+        defer zfi_file.close(io);
+        try std.Io.File.writeStreamingAll(zfi_file, io, "not a zfi index");
+    }
+
+    const expected = try std.fmt.allocPrint(allocator, "error: corrupt index file for: {s}\n", .{fasta});
+    try expectCliFailure(allocator, &.{ ZFASTA_BIN, "stats", fasta }, 1, expected);
+}
 
 test "stats renders the exact nucleotide report" {
     const expected =

--- a/tests/test_stats.zig
+++ b/tests/test_stats.zig
@@ -8,104 +8,89 @@ const main = @import("main");
 const detectType = main.stats.detectType;
 const SequenceType = main.stats.SequenceType;
 
-// ============================================================================
-// detectType tests
-// ============================================================================
+// --- Type detection ---
 
-test "detectType - all ACGT is nucleotide" {
+fn countSymbols(symbols: []const u8) [256]u64 {
     var counts: [256]u64 = .{0} ** 256;
-    counts['A'] = 250;
-    counts['C'] = 250;
-    counts['G'] = 250;
-    counts['T'] = 250;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, 1000));
+    for (symbols) |symbol| counts[symbol] += 1;
+    return counts;
 }
 
-test "detectType - ACGTN is nucleotide" {
-    var counts: [256]u64 = .{0} ** 256;
-    counts['A'] = 200;
-    counts['C'] = 200;
-    counts['G'] = 200;
-    counts['T'] = 200;
-    counts['N'] = 200;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, 1000));
+test "detectType classifies representative alphabets" {
+    const Case = struct {
+        symbols: []const u8,
+        expected: SequenceType,
+    };
+    const cases = [_]Case{
+        .{ .symbols = "", .expected = .nucleotide },
+        .{ .symbols = "ACGTACGT", .expected = .nucleotide },
+        .{ .symbols = "acgtacgt", .expected = .nucleotide },
+        .{ .symbols = "ACGTURYSWKMBDHVNacgturyswkmbdhvn", .expected = .nucleotide },
+        .{ .symbols = "EFLPQXZJO*eflpqxzjo*", .expected = .protein },
+    };
+
+    for (cases) |case| {
+        const counts = countSymbols(case.symbols);
+
+        try std.testing.expectEqual(case.expected, detectType(&counts, case.symbols.len));
+    }
 }
 
-test "detectType - full IUPAC ambiguity alphabet is nucleotide" {
-    var counts: [256]u64 = .{0} ** 256;
-    const letters = "ACGTURYSWKMBDHVNacgturyswkmbdhvnu";
-    for (letters) |byte| counts[byte] += 1;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, letters.len));
+test "detectType uses a strict overflow-safe 90 percent boundary" {
+    const Case = struct {
+        total: u64,
+        nucleotide: u64,
+        expected: SequenceType,
+    };
+    const cases = [_]Case{
+        .{ .total = 10, .nucleotide = 9, .expected = .protein },
+        .{ .total = 10, .nucleotide = 10, .expected = .nucleotide },
+        .{ .total = 11, .nucleotide = 10, .expected = .nucleotide },
+        .{ .total = 1000, .nucleotide = 900, .expected = .protein },
+        .{ .total = 1000, .nucleotide = 901, .expected = .nucleotide },
+        .{
+            .total = 2_300_000_000_000_000_000,
+            .nucleotide = 2_070_000_000_000_000_000,
+            .expected = .protein,
+        },
+        .{
+            .total = 2_300_000_000_000_000_000,
+            .nucleotide = 2_070_000_000_000_000_001,
+            .expected = .nucleotide,
+        },
+    };
+
+    for (cases) |case| {
+        var counts: [256]u64 = .{0} ** 256;
+        counts['A'] = case.nucleotide;
+        counts['L'] = case.total - case.nucleotide;
+
+        try std.testing.expectEqual(case.expected, detectType(&counts, case.total));
+    }
 }
 
-test "detectType - mixed amino acids is protein" {
-    var counts: [256]u64 = .{0} ** 256;
-    counts['M'] = 100;
-    counts['A'] = 100;
-    counts['L'] = 100;
-    counts['F'] = 100;
-    counts['P'] = 100;
-    counts['W'] = 100;
-    counts['H'] = 100;
-    counts['K'] = 100;
-    counts['D'] = 100;
-    counts['E'] = 100;
-    try std.testing.expectEqual(SequenceType.protein, detectType(&counts, 1000));
+test "detectType matches its threshold across deterministic fuzzy inputs" {
+    const nucleotide_codes = "ACGTURYSWKMBDHVNacgturyswkmbdhvn";
+    const protein_only_codes = "EFLPQXZJO*eflpqxzjo*";
+    var prng = std.Random.DefaultPrng.init(0x7a_fa_57_a7_5);
+    const random = prng.random();
+
+    for (0..4096) |i| {
+        const total = random.intRangeAtMost(u64, 1, 1_000_000);
+        const nucleotide = random.intRangeAtMost(u64, 0, total);
+        var counts: [256]u64 = .{0} ** 256;
+        counts[nucleotide_codes[i % nucleotide_codes.len]] = nucleotide;
+        counts[protein_only_codes[i % protein_only_codes.len]] = total - nucleotide;
+        const expected: SequenceType = if (@as(u128, nucleotide) * 10 > @as(u128, total) * 9)
+            .nucleotide
+        else
+            .protein;
+
+        try std.testing.expectEqual(expected, detectType(&counts, total));
+    }
 }
 
-test "detectType - below 90% threshold is protein" {
-    var counts: [256]u64 = .{0} ** 256;
-    counts['A'] = 200;
-    counts['C'] = 200;
-    counts['G'] = 200;
-    // A+C+G = 600 out of 700, which is 85.7% => protein.
-    // Use letters outside the IUPAC nucleotide alphabet for the remainder.
-    counts['L'] = 50;
-    counts['F'] = 50;
-    try std.testing.expectEqual(SequenceType.protein, detectType(&counts, 700));
-}
-
-test "detectType - exactly 91% is nucleotide" {
-    var counts: [256]u64 = .{0} ** 256;
-    counts['A'] = 910;
-    counts['L'] = 90;
-    // ACGTN = 910/1000 = 91% > 90%
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, 1000));
-}
-
-test "detectType - empty is nucleotide (default)" {
-    var counts: [256]u64 = .{0} ** 256;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, 0));
-}
-
-test "detectType - lowercase nucleotides" {
-    var counts: [256]u64 = .{0} ** 256;
-    counts['a'] = 250;
-    counts['c'] = 250;
-    counts['g'] = 250;
-    counts['t'] = 250;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, 1000));
-}
-
-test "detectType - large totals do not overflow the 90% threshold" {
-    var counts: [256]u64 = .{0} ** 256;
-    // total*9 and nuc*10 both overflow u64 at this scale; u128 keeps the compare correct.
-    const total: u64 = 2_300_000_000_000_000_000;
-    const nuc_hi: u64 = 2_070_000_000_000_000_001;
-    counts['A'] = nuc_hi;
-    counts['L'] = total - nuc_hi;
-    try std.testing.expectEqual(SequenceType.nucleotide, detectType(&counts, total));
-
-    counts = .{0} ** 256;
-    const nuc_lo: u64 = 2_070_000_000_000_000_000;
-    counts['A'] = nuc_lo;
-    counts['L'] = total - nuc_lo;
-    try std.testing.expectEqual(SequenceType.protein, detectType(&counts, total));
-}
-
-// ============================================================================
-// Integration: stats via process spawn
-// ============================================================================
+// --- CLI reports ---
 
 const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
 
@@ -118,7 +103,7 @@ fn runStatsAndCapture(allocator: std.mem.Allocator, fasta_path: []const u8) ![]u
         .argv = &.{ ZFASTA_BIN, "stats", fasta_path },
         .stdout = .pipe,
     });
-    defer proc.kill(io);
+    errdefer proc.kill(io);
 
     var read_buf: [4096]u8 = undefined;
     var stdout_reader = proc.stdout.?.reader(io, &read_buf);
@@ -131,9 +116,8 @@ fn runStatsAndCapture(allocator: std.mem.Allocator, fasta_path: []const u8) ![]u
 }
 
 test "stats renders the exact nucleotide report" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const output = try runStatsAndCapture(arena.allocator(), "tests/data/simple.fasta");
+    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/simple.fasta");
+    defer std.testing.allocator.free(output);
 
     const expected =
         \\File:
@@ -181,12 +165,36 @@ test "stats renders the exact nucleotide report" {
     try std.testing.expectEqualStrings(expected, output);
 }
 
-test "stats renders the exact complete protein field set" {
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const output = try runStatsAndCapture(arena.allocator(), "tests/data/proteome.fasta");
+test "stats renders the exact protein report" {
+    const output = try runStatsAndCapture(std.testing.allocator, "tests/data/proteome.fasta");
+    defer std.testing.allocator.free(output);
 
-    const composition =
+    const expected =
+        \\File:
+        \\  path: tests/data/proteome.fasta
+        \\  index: tests/data/proteome.fasta.zfi
+        \\  size_bytes: 187
+        \\
+        \\Lengths:
+        \\  indexed_records: 2
+        \\  total_symbols: 71
+        \\  shortest_length: 20
+        \\  shortest_name: sp|Q98765|ANOT_MOUSE
+        \\  longest_length: 51
+        \\  longest_name: sp|P12345|PROT_HUMAN
+        \\  mean: 35
+        \\  q1: 20
+        \\  median: 35
+        \\  q3: 51
+        \\  range: 31
+        \\
+        \\Nx:
+        \\  n50: 51
+        \\  l50: 1
+        \\  n90: 20
+        \\  l90: 2
+        \\  aun: 42.27
+        \\
         \\Composition:
         \\  type: protein
         \\  percent_denominator: total_symbols
@@ -221,7 +229,5 @@ test "stats renders the exact complete protein field set" {
         \\  lowercase: 0 0.00%
         \\
     ;
-    const start = std.mem.indexOf(u8, output, "Composition:\n") orelse return error.MissingComposition;
-
-    try std.testing.expectEqualStrings(composition, output[start..]);
+    try std.testing.expectEqualStrings(expected, output);
 }

--- a/tests/test_validate.zig
+++ b/tests/test_validate.zig
@@ -32,7 +32,158 @@ fn expectFixIdempotent(allocator: std.mem.Allocator, broken: []const u8) !void {
     try std.testing.expectEqual(@as(usize, 0), after.events.items.len);
 }
 
-// --- unit tests (moved from src/validator.zig) ---
+fn validateAndDeinitForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !void {
+    var summary = try validator.validateData(allocator, data, .{});
+    defer summary.deinit(allocator);
+}
+
+fn fixAndFreeForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !void {
+    const widths = [_]u32{4};
+    const fixed = try validator.fixData(allocator, data, &widths);
+    defer allocator.free(fixed);
+}
+
+fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.debug.print("required test fixture missing: {s}\n", .{path});
+            return error.RequiredFixtureMissing;
+        },
+        else => |e| return e,
+    };
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const size = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
+    const data = try allocator.alloc(u8, size);
+    errdefer allocator.free(data);
+    const bytes_read = try file.readPositionalAll(io, data, 0);
+    if (bytes_read != data.len) return error.UnexpectedEndOfFile;
+    return data;
+}
+
+fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
+    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
+    const now = std.Io.Clock.Timestamp.now(io, .awake);
+    const nanos: u64 = @intCast(now.raw.toNanoseconds());
+    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.fa", .{ stem, nanos });
+}
+
+fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]u8 {
+    const path = try uniqueArtifactPath(allocator, stem);
+    errdefer allocator.free(path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
+    defer file.close(io);
+    try std.Io.File.writeStreamingAll(file, io, data);
+    return path;
+}
+
+fn scanZfi(allocator: std.mem.Allocator, data: []const u8) !main.indexer.ZfiIndex {
+    return main.indexer.scanZfiData(data, true, allocator);
+}
+
+fn expectHasSideTable(index: *const main.indexer.ZfiIndex) !void {
+    var any_non_uniform = false;
+    for (index.records.items) |rec| {
+        if (!rec.isUniformWidth()) any_non_uniform = true;
+    }
+    try std.testing.expect(any_non_uniform);
+    try std.testing.expect(index.side_tables.items.len > 0);
+}
+
+fn expectAllUniformNoSideTable(index: *const main.indexer.ZfiIndex) !void {
+    for (index.records.items) |rec| {
+        try std.testing.expect(rec.isUniformWidth());
+    }
+    try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
+}
+
+fn writeZfiForData(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const u8) !void {
+    var index = try scanZfi(allocator, data);
+    defer index.deinit(allocator);
+
+    const fasta_file = try std.Io.Dir.cwd().openFile(io, fasta_path, .{});
+    defer fasta_file.close(io);
+    const mtime_ns = main.index_format.timestampToNs((try fasta_file.stat(io)).mtime);
+
+    var zfi_path_buf: [4096]u8 = undefined;
+    const zfi_path = try std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{fasta_path});
+    try main.indexer.writeZfiIndexFile(io, zfi_path, &index, data.len, mtime_ns);
+}
+
+fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
+    var idx = try main.index_format.loadIndexChecked(allocator, io, fasta_path);
+    defer idx.deinit();
+
+    var out = std.Io.Writer.Allocating.init(allocator);
+    errdefer out.deinit();
+    main.getter.extractRegion(&idx, region, &out.writer);
+    return out.toOwnedSlice();
+}
+
+fn fixFormatOnly(allocator: std.mem.Allocator, broken: []const u8) ![]u8 {
+    var summary = try validator.validateData(allocator, broken, .{});
+    defer summary.deinit(allocator);
+    try std.testing.expect(validator.fixRejection(&summary, .{}) == null);
+    return validator.fixData(allocator, broken, summary.record_widths.items);
+}
+
+fn expectValidateClean(allocator: std.mem.Allocator, data: []const u8) !void {
+    var summary = try validator.validateData(allocator, data, .{});
+    defer summary.deinit(allocator);
+    try std.testing.expectEqual(@as(usize, 0), summary.events.items.len);
+}
+
+fn expectFormatFixPreservesRegion(
+    allocator: std.mem.Allocator,
+    stem: []const u8,
+    broken: []const u8,
+    region: []const u8,
+    expected: []const u8,
+) !void {
+    var broken_index = try scanZfi(allocator, broken);
+    defer broken_index.deinit(allocator);
+    try expectHasSideTable(&broken_index);
+
+    const fixed = try fixFormatOnly(allocator, broken);
+    defer allocator.free(fixed);
+    try expectValidateClean(allocator, fixed);
+
+    var fixed_index = try scanZfi(allocator, fixed);
+    defer fixed_index.deinit(allocator);
+    try expectAllUniformNoSideTable(&fixed_index);
+
+    const broken_path = try writeFastaArtifact(allocator, stem, broken);
+    defer allocator.free(broken_path);
+    defer std.Io.Dir.cwd().deleteFile(io, broken_path) catch {};
+    const fixed_path = try writeFastaArtifact(allocator, stem, fixed);
+    defer allocator.free(fixed_path);
+    defer std.Io.Dir.cwd().deleteFile(io, fixed_path) catch {};
+    const broken_zfi = try std.fmt.allocPrint(allocator, "{s}.zfi", .{broken_path});
+    defer allocator.free(broken_zfi);
+    defer std.Io.Dir.cwd().deleteFile(io, broken_zfi) catch {};
+    const fixed_zfi = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fixed_path});
+    defer allocator.free(fixed_zfi);
+    defer std.Io.Dir.cwd().deleteFile(io, fixed_zfi) catch {};
+
+    try writeZfiForData(allocator, broken_path, broken);
+    try writeZfiForData(allocator, fixed_path, fixed);
+
+    const broken_output = try captureExtractRegion(allocator, broken_path, region);
+    defer allocator.free(broken_output);
+    const fixed_output = try captureExtractRegion(allocator, fixed_path, region);
+    defer allocator.free(fixed_output);
+
+    try std.testing.expectEqualStrings(broken_output, fixed_output);
+    try std.testing.expectEqualStrings(expected, fixed_output);
+}
+
+fn zfiEmbeddedName(index: *const main.indexer.ZfiIndex, rec_idx: usize) []const u8 {
+    const rec = index.records.items[rec_idx];
+    return index.name_blob.items[rec.name_offset..][0..rec.name_len];
+}
+
+// --- Unit tests ---
 
 test "validateData reports duplicate and empty sequence" {
     var summary = try validator.validateData(std.testing.allocator, ">dup\nAAAA\n>dup\n", .{});
@@ -45,6 +196,19 @@ test "validateData reports duplicate and empty sequence" {
     try std.testing.expectEqual(@as(usize, 2), summary.header_count);
 }
 
+test "validator operations release allocations on every failure path" {
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        validateAndDeinitForAllocationCheck,
+        .{">dup\nAAAA \n>dup\n"},
+    );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        fixAndFreeForAllocationCheck,
+        .{">seq\nAAAA \n"},
+    );
+}
+
 test "validateData caps retained events and sets truncated" {
     const allocator = std.testing.allocator;
 
@@ -52,20 +216,65 @@ test "validateData caps retained events and sets truncated" {
     defer at_cap.deinit(allocator);
     try at_cap.appendSlice(allocator, ">seq\n");
     var i: usize = 0;
-    while (i < validator.max_validate_events) : (i += 1) {
+    while (i < validator.MAX_VALIDATE_EVENTS) : (i += 1) {
         try at_cap.appendSlice(allocator, "ACGT \n");
     }
 
     var capped = try validator.validateData(allocator, at_cap.items, .{});
     defer capped.deinit(allocator);
     try std.testing.expect(!capped.truncated);
-    try std.testing.expectEqual(validator.max_validate_events, capped.events.items.len);
+    try std.testing.expectEqual(validator.MAX_VALIDATE_EVENTS, capped.events.items.len);
 
     try at_cap.appendSlice(allocator, "ACGT \n");
     var over = try validator.validateData(allocator, at_cap.items, .{});
     defer over.deinit(allocator);
     try std.testing.expect(over.truncated);
-    try std.testing.expectEqual(validator.max_validate_events, over.events.items.len);
+    try std.testing.expectEqual(validator.MAX_VALIDATE_EVENTS, over.events.items.len);
+    try std.testing.expectEqual(
+        validator.MAX_VALIDATE_EVENTS + 1,
+        over.kind_counts[@intFromEnum(validator.Kind.trailing_whitespace)],
+    );
+}
+
+test "event cap retains later fix blockers" {
+    const allocator = std.testing.allocator;
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(allocator);
+    try input.appendSlice(allocator, ">dup\n");
+    for (0..validator.MAX_VALIDATE_EVENTS) |_| {
+        try input.appendSlice(allocator, "A \n");
+    }
+    try input.appendSlice(allocator, ">dup\nA\n");
+
+    var summary = try validator.validateData(allocator, input.items, .{});
+    defer summary.deinit(allocator);
+
+    try std.testing.expect(summary.truncated);
+    try std.testing.expectEqual(@as(usize, 1), summary.error_count);
+    try std.testing.expectEqual(validator.Kind.duplicate_name, validator.fixRejection(&summary, .{}).?);
+    try std.testing.expectEqual(
+        validator.Kind.duplicate_name,
+        validator.fixRejection(&summary, .{ .fix_format_only = true }).?,
+    );
+}
+
+test "event cap retains warnings left after format fix" {
+    const allocator = std.testing.allocator;
+    var input: std.ArrayList(u8) = .empty;
+    defer input.deinit(allocator);
+    try input.appendSlice(allocator, ">seq\n");
+    for (0..validator.MAX_VALIDATE_EVENTS) |_| {
+        try input.appendSlice(allocator, "A \n");
+    }
+    try input.appendSlice(allocator, ">empty\n");
+
+    var summary = try validator.validateData(allocator, input.items, .{});
+    defer summary.deinit(allocator);
+
+    try std.testing.expect(summary.truncated);
+    try std.testing.expectEqual(validator.MAX_VALIDATE_EVENTS + 1, summary.warning_count);
+    try std.testing.expectEqual(@as(u8, 2), validator.exitCodeForOptions(&summary, .{ .fix = true }));
+    try std.testing.expectEqual(@as(u8, 1), validator.exitCodeForOptions(&summary, .{ .fix = true, .strict = true }));
 }
 
 test "renderJsonEvent keeps long names without 256-byte truncation" {
@@ -144,7 +353,7 @@ test "renderJsonEvent escapes invalid UTF-8 name bytes" {
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
     defer parsed.deinit();
-    // JSON \u00ff decodes to Unicode U+00FF (ÿ), not the raw invalid FASTA byte.
+    // JSON \u00ff decodes to Unicode U+00FF, not the raw invalid FASTA byte.
     try std.testing.expectEqualStrings("seq\u{00ff}name", parsed.value.object.get("name").?.string);
 }
 
@@ -168,7 +377,7 @@ test "validateData to JSON keeps invalid UTF-8 header bytes escapable" {
     try std.testing.expectEqualStrings("bad\u{00ff}name", parsed.value.object.get("name").?.string);
 }
 
-test "gates fixture: invalid UTF-8 and long header are visible to validate" {
+test "gates fixture: invalid UTF-8 names remain reportable" {
     const allocator = std.testing.allocator;
 
     const utf8_data = try readTestFile(allocator, "tests/data/gates/invalid_utf8_header.fasta");
@@ -184,6 +393,10 @@ test "gates fixture: invalid UTF-8 and long header are visible to validate" {
     defer allocator.free(json);
     try std.testing.expect(std.unicode.utf8ValidateSlice(json));
     try std.testing.expect(std.mem.indexOf(u8, json, "\\u00ff") != null);
+}
+
+test "gates fixture: long headers remain visible" {
+    const allocator = std.testing.allocator;
 
     const long_data = try readTestFile(allocator, "tests/data/gates/long_header.fasta");
     defer allocator.free(long_data);
@@ -224,6 +437,7 @@ test "validate --json --summary reports sequence type sample fields" {
         .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
         else => return error.ChildProcessFailed,
     }
+    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
 
     const parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, result.stdout, " \t\r\n"), .{});
     defer parsed.deinit();
@@ -258,6 +472,17 @@ test "validateData tracks line-width and trailing whitespace warnings" {
 
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .trailing_whitespace));
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .inconsistent_line_widths));
+}
+
+test "validateData rejects a final sequence line wider than the established width" {
+    var summary = try validator.validateData(std.testing.allocator, ">seq\nAA\nAAAA\n", .{});
+    defer summary.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .inconsistent_line_widths));
+    const event = summary.events.items[0];
+    try std.testing.expectEqual(@as(u32, 2), event.expected_width);
+    try std.testing.expectEqual(@as(u32, 4), event.actual_width);
+    try std.testing.expectEqual(@as(usize, 3), event.line);
 }
 
 test "validateData checks schemas" {
@@ -360,95 +585,7 @@ test "fixData does not remove empty sequence warnings" {
     try std.testing.expectEqual(@as(usize, 1), countKind(&after, .empty_sequence));
 }
 
-// --- integration tests ---
-
-fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
-        error.FileNotFound => {
-            std.debug.print("required test fixture missing: {s}\n", .{path});
-            return error.RequiredFixtureMissing;
-        },
-        else => |e| return e,
-    };
-    defer file.close(io);
-    const stat = try file.stat(io);
-    const data = try allocator.alloc(u8, stat.size);
-    _ = try file.readPositionalAll(io, data, 0);
-    return data;
-}
-
-fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
-    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.fa", .{ stem, nanos });
-}
-
-fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]const u8 {
-    const path = try uniqueArtifactPath(allocator, stem);
-    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
-    defer file.close(io);
-    try std.Io.File.writeStreamingAll(file, io, data);
-    return path;
-}
-
-fn scanZfi(allocator: std.mem.Allocator, data: []const u8) !main.indexer.ZfiIndex {
-    return main.indexer.scanZfiData(data, true, allocator);
-}
-
-fn expectHasSideTable(index: *const main.indexer.ZfiIndex) !void {
-    var any_non_uniform = false;
-    for (index.records.items) |rec| {
-        if (!rec.isUniformWidth()) any_non_uniform = true;
-    }
-    try std.testing.expect(any_non_uniform);
-    try std.testing.expect(index.side_tables.items.len > 0);
-}
-
-fn expectAllUniformNoSideTable(index: *const main.indexer.ZfiIndex) !void {
-    for (index.records.items) |rec| {
-        try std.testing.expect(rec.isUniformWidth());
-    }
-    try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
-}
-
-fn writeZfiForData(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const u8) !void {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    defer arena.deinit();
-
-    var index = try scanZfi(arena.allocator(), data);
-    defer index.deinit(arena.allocator());
-
-    const fasta_file = try std.Io.Dir.cwd().openFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    const mtime_ns = main.index_format.timestampToNs((try fasta_file.stat(io)).mtime);
-
-    var zfi_path_buf: [4096]u8 = undefined;
-    const zfi_path = try std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{fasta_path});
-    try main.indexer.writeZfiIndexFile(io, zfi_path, &index, data.len, mtime_ns);
-}
-
-fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(std.testing.allocator, io, fasta_path);
-    defer idx.deinit();
-
-    var out = std.Io.Writer.Allocating.init(allocator);
-    main.getter.extractRegion(&idx, region, &out.writer);
-    return out.toOwnedSlice();
-}
-
-fn fixFormatOnly(allocator: std.mem.Allocator, broken: []const u8) ![]u8 {
-    var summary = try validator.validateData(allocator, broken, .{});
-    defer summary.deinit(allocator);
-    try std.testing.expect(validator.fixRejection(&summary, .{}) == null);
-    return validator.fixData(allocator, broken, summary.record_widths.items);
-}
-
-fn expectValidateClean(allocator: std.mem.Allocator, data: []const u8) !void {
-    var summary = try validator.validateData(allocator, data, .{});
-    defer summary.deinit(allocator);
-    try std.testing.expectEqual(@as(usize, 0), summary.events.items.len);
-}
+// --- Integration tests ---
 
 test "validate --fix -o matches fixData rewrite" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -467,7 +604,7 @@ test "validate --fix -o matches fixData rewrite" {
     const expected = try validator.fixData(allocator, broken, summary.record_widths.items);
 
     const in_path = try writeFastaArtifact(allocator, "validate-fix-cli-in", broken);
-    const out_path = try uniqueArtifactPath(allocator, "validate-fix-cli-out");
+    const out_path = try writeFastaArtifact(allocator, "validate-fix-cli-out", "previous output\n");
     defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, out_path) catch {};
 
@@ -492,6 +629,44 @@ test "validate --fix -o matches fixData rewrite" {
     try std.testing.expectEqualStrings(expected, got);
 }
 
+test "validate --fix rejects an alternate spelling of the input path" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const broken = ">seq\nAAAA  \n";
+    const in_path = try writeFastaArtifact(allocator, "validate-fix-input-alias", broken);
+    defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
+    const output_alias = try std.fmt.allocPrint(allocator, "./{s}", .{in_path});
+
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    const spawn_io = threaded.io();
+
+    const result = try std.process.run(allocator, spawn_io, .{
+        .argv = &.{ ZFASTA_BIN, "validate", "--fix", "-o", output_alias, in_path },
+        .stdout_limit = .limited(64 * 1024),
+        .stderr_limit = .limited(64 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try std.testing.expectEqual(@as(u8, 1), code),
+        else => return error.ChildProcessFailed,
+    }
+    const expected_error = try std.fmt.allocPrint(
+        allocator,
+        "error: validate --fix will not overwrite input: {s}\n",
+        .{in_path},
+    );
+    try std.testing.expectEqual(@as(usize, 0), result.stdout.len);
+    try std.testing.expectEqualStrings(expected_error, result.stderr);
+
+    const input_after = try readTestFile(allocator, in_path);
+    try std.testing.expectEqualStrings(broken, input_after);
+}
+
 test "validate --fix succeeds after event list truncation" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
@@ -501,7 +676,7 @@ test "validate --fix succeeds after event list truncation" {
     defer input.deinit(allocator);
     try input.appendSlice(allocator, ">seq\n");
     var i: usize = 0;
-    while (i <= validator.max_validate_events) : (i += 1) {
+    while (i <= validator.MAX_VALIDATE_EVENTS) : (i += 1) {
         try input.appendSlice(allocator, "A \n");
     }
 
@@ -537,7 +712,7 @@ test "validate --fix succeeds after event list truncation" {
     try std.testing.expectEqual(@as(usize, 0), fixed_summary.events.items.len);
 }
 
-test "validate --fix then index uses uniform O(1) path on crafted messy FASTA" {
+test "format fix produces uniform indexed retrieval for crafted messy FASTA" {
     const broken =
         \\>messy_seq widths and trailing ws
         \\AAAA    
@@ -549,35 +724,16 @@ test "validate --fix then index uses uniform O(1) path on crafted messy FASTA" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-
-    var broken_index = try scanZfi(allocator, broken);
-    defer broken_index.deinit(allocator);
-    try expectHasSideTable(&broken_index);
-
-    const fixed = try fixFormatOnly(allocator, broken);
-    try expectValidateClean(allocator, fixed);
-
-    var fixed_index = try scanZfi(allocator, fixed);
-    defer fixed_index.deinit(allocator);
-    try expectAllUniformNoSideTable(&fixed_index);
-
-    const path = try writeFastaArtifact(allocator, "validate-fix-crafted", fixed);
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{path});
-    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
-    try writeZfiForData(allocator, path, fixed);
-
-    const got = try captureExtractRegion(allocator, path, "messy_seq:1-14");
     const expected =
         \\>messy_seq:1-14
         \\AAAACCCCGGGGTT
         \\
     ;
-    try std.testing.expectEqualStrings(expected, got);
+
+    try expectFormatFixPreservesRegion(allocator, "validate-fix-crafted", broken, "messy_seq:1-14", expected);
 }
 
-test "validate --fix then index then get on mixed_widths fixture" {
+test "format fix preserves indexed retrieval for mixed_widths fixture" {
     const broken = try readTestFile(
         std.testing.allocator,
         "bench/shared/cache/messy_fixtures/mixed_widths.fasta",
@@ -587,44 +743,16 @@ test "validate --fix then index then get on mixed_widths fixture" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-
-    var broken_index = try scanZfi(allocator, broken);
-    defer broken_index.deinit(allocator);
-    try expectHasSideTable(&broken_index);
-
-    const fixed = try fixFormatOnly(allocator, broken);
-    try expectValidateClean(allocator, fixed);
-
-    var fixed_index = try scanZfi(allocator, fixed);
-    defer fixed_index.deinit(allocator);
-    try expectAllUniformNoSideTable(&fixed_index);
-
-    const messy_path = try writeFastaArtifact(allocator, "validate-fix-messy", broken);
-    const fixed_path = try writeFastaArtifact(allocator, "validate-fix-fixed", fixed);
-    const messy_zfi = try std.fmt.allocPrint(allocator, "{s}.zfi", .{messy_path});
-    const fixed_zfi = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fixed_path});
-    defer std.Io.Dir.cwd().deleteFile(io, messy_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fixed_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, messy_zfi) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, fixed_zfi) catch {};
-
-    try writeZfiForData(allocator, messy_path, broken);
-    try writeZfiForData(allocator, fixed_path, fixed);
-
-    const region = "mixed_widths:3-24";
-    const messy_out = try captureExtractRegion(allocator, messy_path, region);
-    const fixed_out = try captureExtractRegion(allocator, fixed_path, region);
-    try std.testing.expectEqualStrings(messy_out, fixed_out);
-
     const expected =
         \\>mixed_widths:3-24
         \\AACCCCGGGGTTTTAAAACCCC
         \\
     ;
-    try std.testing.expectEqualStrings(expected, fixed_out);
+
+    try expectFormatFixPreservesRegion(allocator, "validate-fix-mixed", broken, "mixed_widths:3-24", expected);
 }
 
-test "validate --fix then index then get on trailing_whitespace fixture" {
+test "format fix preserves indexed retrieval for trailing_whitespace fixture" {
     const broken = try readTestFile(
         std.testing.allocator,
         "bench/shared/cache/messy_fixtures/trailing_whitespace.fasta",
@@ -634,37 +762,19 @@ test "validate --fix then index then get on trailing_whitespace fixture" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-
-    var broken_index = try scanZfi(allocator, broken);
-    defer broken_index.deinit(allocator);
-    try expectHasSideTable(&broken_index);
-
-    const fixed = try fixFormatOnly(allocator, broken);
-    try expectValidateClean(allocator, fixed);
-
-    var fixed_index = try scanZfi(allocator, fixed);
-    defer fixed_index.deinit(allocator);
-    try expectAllUniformNoSideTable(&fixed_index);
-
-    const fixed_path = try writeFastaArtifact(allocator, "validate-fix-trail", fixed);
-    const zfi_path = try std.fmt.allocPrint(allocator, "{s}.zfi", .{fixed_path});
-    defer std.Io.Dir.cwd().deleteFile(io, fixed_path) catch {};
-    defer std.Io.Dir.cwd().deleteFile(io, zfi_path) catch {};
-
-    try writeZfiForData(allocator, fixed_path, fixed);
-
-    const got = try captureExtractRegion(allocator, fixed_path, "trailing_whitespace:1-16");
     const expected =
         \\>trailing_whitespace:1-16
         \\AAAACCCCGGGGTTTT
         \\
     ;
-    try std.testing.expectEqualStrings(expected, got);
-}
 
-fn zfiEmbeddedName(index: *const main.indexer.ZfiIndex, rec_idx: usize) []const u8 {
-    const rec = index.records.items[rec_idx];
-    return index.name_blob.items[rec.name_offset..][0..rec.name_len];
+    try expectFormatFixPreservesRegion(
+        allocator,
+        "validate-fix-trailing",
+        broken,
+        "trailing_whitespace:1-16",
+        expected,
+    );
 }
 
 test "validator and indexer agree on tests/data/validator_indexer_agreement.fasta" {
@@ -683,7 +793,7 @@ test "validator and indexer agree on tests/data/validator_indexer_agreement.fast
     try std.testing.expect(std.mem.indexOf(u8, data, ">empty_rec\n") != null);
     try std.testing.expect(std.mem.indexOf(u8, data, " \n") != null or std.mem.indexOf(u8, data, "\t\n") != null);
 
-    // --- validator: every listed layout issue is visible ---
+    // Validator must expose every layout feature encoded by the fixture.
     var summary = try validator.validateData(allocator, data, .{});
     defer summary.deinit(allocator);
 
@@ -697,7 +807,7 @@ test "validator and indexer agree on tests/data/validator_indexer_agreement.fast
     try std.testing.expectEqual(@as(usize, 6), summary.header_count);
     try std.testing.expectEqual(@as(usize, 5), summary.sequence_count);
 
-    // --- indexer: same non-empty catalog, side tables for messy layout ---
+    // Indexer must retain the same non-empty catalog and mark messy geometry.
     var index = try scanZfi(allocator, data);
     defer index.deinit(allocator);
 

--- a/tests/test_validate.zig
+++ b/tests/test_validate.zig
@@ -230,7 +230,7 @@ test "validate --json --summary reports sequence type sample fields" {
     try std.testing.expectEqualStrings("nucleotide", parsed.value.object.get("sequence_type").?.string);
     try std.testing.expectEqual(@as(i64, 4), parsed.value.object.get("type_bases_sampled").?.integer);
     try std.testing.expectEqual(
-        @as(i64, @intCast(main.stats.validate_type_sample_bases)),
+        @as(i64, @intCast(main.stats.VALIDATE_TYPE_SAMPLE_BASES)),
         parsed.value.object.get("type_sample_cap").?.integer,
     );
 }
@@ -429,8 +429,8 @@ fn writeZfiForData(allocator: std.mem.Allocator, fasta_path: []const u8, data: [
 }
 
 fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(io, fasta_path);
-    defer idx.deinit(io);
+    var idx = try main.index_format.loadIndexChecked(std.testing.allocator, io, fasta_path);
+    defer idx.deinit();
 
     var out = std.Io.Writer.Allocating.init(allocator);
     main.getter.extractRegion(&idx, region, &out.writer);

--- a/tests/test_validate.zig
+++ b/tests/test_validate.zig
@@ -11,6 +11,10 @@ const validator = main.validator;
 
 const ZFASTA_BIN = utility.ZFASTA_BIN;
 const expectCliResult = utility.expectCliResult;
+const readTestFile = utility.readRequiredFile;
+const writeFastaArtifact = utility.writeFastaArtifact;
+const writeZfi = utility.writeZfi;
+const captureExtractRegion = utility.captureExtractRegion;
 
 fn countKind(summary: *const validator.Summary, kind: validator.Kind) usize {
     var count: usize = 0;
@@ -31,6 +35,10 @@ fn expectFixIdempotent(allocator: std.mem.Allocator, broken: []const u8) !void {
     var after = try validator.validateData(allocator, fixed, .{});
     defer after.deinit(allocator);
     try std.testing.expectEqual(@as(usize, 0), after.events.items.len);
+
+    const fixed_again = try validator.fixData(allocator, fixed, after.record_widths.items);
+    defer allocator.free(fixed_again);
+    try std.testing.expectEqualStrings(fixed, fixed_again);
 }
 
 fn validateAndDeinitForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) !void {
@@ -44,32 +52,37 @@ fn fixAndFreeForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) 
     defer allocator.free(fixed);
 }
 
-fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
-    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
-        error.FileNotFound => {
-            std.debug.print("required test fixture missing: {s}\n", .{path});
-            return error.RequiredFixtureMissing;
-        },
-        else => |e| return e,
-    };
-    defer file.close(io);
-    const stat = try file.stat(io);
-    const size = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
-    const data = try allocator.alloc(u8, size);
-    errdefer allocator.free(data);
-    const bytes_read = try file.readPositionalAll(io, data, 0);
-    if (bytes_read != data.len) return error.UnexpectedEndOfFile;
-    return data;
-}
+fn fuzzValidator(_: void, smith: *std.testing.Smith) !void {
+    var storage: [512]u8 = undefined;
+    const data = storage[0..smith.slice(&storage)];
 
-fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]u8 {
-    const path = try utility.uniqueArtifactPath(allocator, stem, "fa");
-    errdefer allocator.free(path);
-    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
-    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
-    defer file.close(io);
-    try std.Io.File.writeStreamingAll(file, io, data);
-    return path;
+    var summary = try validator.validateData(std.testing.allocator, data, .{});
+    defer summary.deinit(std.testing.allocator);
+
+    try std.testing.expect(summary.events.items.len <= validator.MAX_VALIDATE_EVENTS);
+    try std.testing.expect(summary.sequence_count <= summary.header_count);
+    try std.testing.expectEqual(summary.header_count, summary.record_widths.items.len);
+    var total_kind_count: usize = 0;
+    for (summary.kind_counts) |kind_count| total_kind_count += kind_count;
+    try std.testing.expectEqual(summary.error_count + summary.warning_count, total_kind_count);
+    try std.testing.expect(summary.format_warning_count <= summary.warning_count);
+    for (summary.record_widths.items) |width| try std.testing.expect(width > 0);
+
+    if (validator.fixRejection(&summary, .{}) == null) {
+        const fixed = try validator.fixData(std.testing.allocator, data, summary.record_widths.items);
+        defer std.testing.allocator.free(fixed);
+
+        var fixed_summary = try validator.validateData(std.testing.allocator, fixed, .{});
+        defer fixed_summary.deinit(std.testing.allocator);
+        try std.testing.expect(validator.fixRejection(&fixed_summary, .{}) == null);
+        const fixed_again = try validator.fixData(
+            std.testing.allocator,
+            fixed,
+            fixed_summary.record_widths.items,
+        );
+        defer std.testing.allocator.free(fixed_again);
+        try std.testing.expectEqualStrings(fixed, fixed_again);
+    }
 }
 
 fn scanZfi(allocator: std.mem.Allocator, data: []const u8) !main.indexer.ZfiIndex {
@@ -90,29 +103,6 @@ fn expectAllUniformNoSideTable(index: *const main.indexer.ZfiIndex) !void {
         try std.testing.expect(rec.isUniformWidth());
     }
     try std.testing.expectEqual(@as(usize, 0), index.side_tables.items.len);
-}
-
-fn writeZfiForData(allocator: std.mem.Allocator, fasta_path: []const u8, data: []const u8) !void {
-    var index = try scanZfi(allocator, data);
-    defer index.deinit(allocator);
-
-    const fasta_file = try std.Io.Dir.cwd().openFile(io, fasta_path, .{});
-    defer fasta_file.close(io);
-    const mtime_ns = main.index_format.timestampToNs((try fasta_file.stat(io)).mtime);
-
-    var zfi_path_buf: [4096]u8 = undefined;
-    const zfi_path = try std.fmt.bufPrint(&zfi_path_buf, "{s}.zfi", .{fasta_path});
-    try main.indexer.writeZfiIndexFile(io, zfi_path, &index, data.len, mtime_ns);
-}
-
-fn captureExtractRegion(allocator: std.mem.Allocator, fasta_path: []const u8, region: []const u8) ![]u8 {
-    var idx = try main.index_format.loadIndexChecked(allocator, io, fasta_path);
-    defer idx.deinit();
-
-    var out = std.Io.Writer.Allocating.init(allocator);
-    errdefer out.deinit();
-    main.getter.extractRegion(&idx, region, &out.writer);
-    return out.toOwnedSlice();
 }
 
 fn fixFormatOnly(allocator: std.mem.Allocator, broken: []const u8) ![]u8 {
@@ -147,10 +137,14 @@ fn expectFormatFixPreservesRegion(
     defer fixed_index.deinit(allocator);
     try expectAllUniformNoSideTable(&fixed_index);
 
-    const broken_path = try writeFastaArtifact(allocator, stem, broken);
+    const broken_stem = try std.fmt.allocPrint(allocator, "{s}-broken", .{stem});
+    defer allocator.free(broken_stem);
+    const fixed_stem = try std.fmt.allocPrint(allocator, "{s}-fixed", .{stem});
+    defer allocator.free(fixed_stem);
+    const broken_path = try writeFastaArtifact(allocator, broken_stem, broken);
     defer allocator.free(broken_path);
     defer std.Io.Dir.cwd().deleteFile(io, broken_path) catch {};
-    const fixed_path = try writeFastaArtifact(allocator, stem, fixed);
+    const fixed_path = try writeFastaArtifact(allocator, fixed_stem, fixed);
     defer allocator.free(fixed_path);
     defer std.Io.Dir.cwd().deleteFile(io, fixed_path) catch {};
     const broken_zfi = try std.fmt.allocPrint(allocator, "{s}.zfi", .{broken_path});
@@ -160,8 +154,8 @@ fn expectFormatFixPreservesRegion(
     defer allocator.free(fixed_zfi);
     defer std.Io.Dir.cwd().deleteFile(io, fixed_zfi) catch {};
 
-    try writeZfiForData(allocator, broken_path, broken);
-    try writeZfiForData(allocator, fixed_path, fixed);
+    try writeZfi(allocator, broken_path, broken, true);
+    try writeZfi(allocator, fixed_path, fixed, true);
 
     const broken_output = try captureExtractRegion(allocator, broken_path, region);
     defer allocator.free(broken_output);
@@ -177,7 +171,7 @@ fn zfiEmbeddedName(index: *const main.indexer.ZfiIndex, rec_idx: usize) []const 
     return index.name_blob.items[rec.name_offset..][0..rec.name_len];
 }
 
-// --- Unit tests ---
+// --- Validation and report contracts ---
 
 test "[cli] - [validate]: rejects unknown options regardless of position" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
@@ -201,7 +195,7 @@ test "[cli] - [validate]: rejects unknown options regardless of position" {
     );
 }
 
-test "[cli] - [validate]: rejects invalid option combinations and paths" {
+test "[cli] - [validate]: rejects invalid arguments with exact diagnostics" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -227,13 +221,45 @@ test "[cli] - [validate]: rejects invalid option combinations and paths" {
             .argv = &.{ ZFASTA_BIN, "validate", "tests/data/definitely-missing-cli-failure.fasta" },
             .stderr = "error: file not found: tests/data/definitely-missing-cli-failure.fasta\n",
         },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "tests/data/simple.fasta", "tests/data/single.fasta" },
+            .stderr = "error: validate accepts exactly one FASTA path\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "-o" },
+            .stderr = "error: -o requires an output path\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--schema" },
+            .stderr = "error: --schema requires uniprot or refseq\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--schema", "ena", "tests/data/simple.fasta" },
+            .stderr = "error: --schema must be uniprot or refseq\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--custom-alphabet" },
+            .stderr = "error: --custom-alphabet requires characters\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--max-header-len" },
+            .stderr = "error: --max-header-len requires a positive integer\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--max-header-len", "0", "tests/data/simple.fasta" },
+            .stderr = "error: --max-header-len requires a positive integer\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--fix", "tests/data/simple.fasta" },
+            .stderr = "error: validate --fix requires -o <output.fa>\n",
+        },
     };
     for (cases) |case| {
         try expectCliResult(allocator, case.argv, 1, "", case.stderr);
     }
 }
 
-test "[cli] - [validate]: warnings use exit 2 and exact stdout" {
+test "[cli] - [validate report]: returns exact status and output for clean and warning reports" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -241,6 +267,9 @@ test "[cli] - [validate]: warnings use exit 2 and exact stdout" {
     const path = try writeFastaArtifact(allocator, "cli-validate-warn", ">empty_rec\n");
     defer allocator.free(path);
     defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    const invalid_path = try writeFastaArtifact(allocator, "cli-validate-error", "not FASTA\n");
+    defer allocator.free(invalid_path);
+    defer std.Io.Dir.cwd().deleteFile(io, invalid_path) catch {};
 
     try expectCliResult(
         allocator,
@@ -249,9 +278,61 @@ test "[cli] - [validate]: warnings use exit 2 and exact stdout" {
         "WARNING: line 1: empty sequence 'empty_rec'\n",
         "",
     );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--strict", path },
+        1,
+        "WARNING: line 1: empty sequence 'empty_rec'\n",
+        "",
+    );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--json", path },
+        2,
+        "{\"schema_version\":\"v1\",\"level\":\"warning\",\"line\":1,\"kind\":\"empty_sequence\",\"message\":\"empty sequence 'empty_rec'\",\"name\":\"empty_rec\"}\n",
+        "",
+    );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "tests/data/simple.fasta" },
+        0,
+        "OK: no issues found\n",
+        "",
+    );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", invalid_path },
+        1,
+        "ERROR: line 1: no sequences found\n",
+        "",
+    );
 }
 
-test "validateData reports duplicate and empty sequence" {
+test "[cli] - [validate options]: applies schema, alphabet, and header limits together" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const path = try writeFastaArtifact(allocator, "cli-validate-options", ">bad\nACGTZ\n");
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try expectCliResult(
+        allocator,
+        &.{
+            ZFASTA_BIN,          "validate",
+            "--schema",          "refseq",
+            "--custom-alphabet", "ACGTZ",
+            "--max-header-len",  "2",
+            path,
+        },
+        2,
+        "WARNING: line 1: header exceeds 2 bytes\n" ++
+            "WARNING: line 1: header for 'bad' does not match schema\n",
+        "",
+    );
+}
+
+test "[unit] - [validate scan]: reports duplicate names and empty records" {
     var summary = try validator.validateData(std.testing.allocator, ">dup\nAAAA\n>dup\n", .{});
     defer summary.deinit(std.testing.allocator);
 
@@ -262,7 +343,20 @@ test "validateData reports duplicate and empty sequence" {
     try std.testing.expectEqual(@as(usize, 2), summary.header_count);
 }
 
-test "validator operations release allocations on every failure path" {
+test "[edge] - [validate scan]: reports the complete empty-file contract" {
+    var summary = try validator.validateData(std.testing.allocator, "", .{});
+    defer summary.deinit(std.testing.allocator);
+
+    try std.testing.expectEqual(@as(usize, 0), summary.header_count);
+    try std.testing.expectEqual(@as(usize, 0), summary.sequence_count);
+    try std.testing.expectEqual(@as(usize, 0), summary.record_widths.items.len);
+    try std.testing.expectEqual(@as(usize, 1), summary.error_count);
+    try std.testing.expectEqual(@as(usize, 1), summary.warning_count);
+    try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .no_sequences));
+    try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .missing_terminal_newline));
+}
+
+test "[failure] - [validate operations]: release partial allocations" {
     try std.testing.checkAllAllocationFailures(
         std.testing.allocator,
         validateAndDeinitForAllocationCheck,
@@ -275,7 +369,17 @@ test "validator operations release allocations on every failure path" {
     );
 }
 
-test "validateData caps retained events and sets truncated" {
+test "[fuzz] - [validate scan]: returns bounded summaries and idempotent allowed fixes" {
+    try std.testing.fuzz({}, fuzzValidator, .{ .corpus = &.{
+        "",
+        ">a\nA\n",
+        ">a description\r\nAC\r\nGT",
+        ">a\nAAA \nCC\nGGGG\n",
+        ">bad\xffname\nA\x00C\n",
+    } });
+}
+
+test "[edge] - [validate events]: caps retained events without losing counts" {
     const allocator = std.testing.allocator;
 
     var at_cap: std.ArrayList(u8) = .empty;
@@ -302,7 +406,7 @@ test "validateData caps retained events and sets truncated" {
     );
 }
 
-test "event cap retains later fix blockers" {
+test "[edge] - [validate events]: retains fix blockers after truncation" {
     const allocator = std.testing.allocator;
     var input: std.ArrayList(u8) = .empty;
     defer input.deinit(allocator);
@@ -324,7 +428,7 @@ test "event cap retains later fix blockers" {
     );
 }
 
-test "event cap retains warnings left after format fix" {
+test "[edge] - [validate events]: retains warnings left after a truncated format fix" {
     const allocator = std.testing.allocator;
     var input: std.ArrayList(u8) = .empty;
     defer input.deinit(allocator);
@@ -343,7 +447,7 @@ test "event cap retains warnings left after format fix" {
     try std.testing.expectEqual(@as(u8, 1), validator.exitCodeForOptions(&summary, .{ .fix = true, .strict = true }));
 }
 
-test "renderJsonEvent keeps long names without 256-byte truncation" {
+test "[edge] - [validate JSON]: preserves names longer than 256 bytes" {
     const allocator = std.testing.allocator;
     const long_name = "n" ** 400;
 
@@ -363,7 +467,7 @@ test "renderJsonEvent keeps long names without 256-byte truncation" {
     try std.testing.expectEqualStrings(long_name, parsed.value.object.get("name").?.string);
 }
 
-test "renderJsonEvent preserves valid non-ASCII UTF-8 names" {
+test "[unit] - [validate JSON]: preserves valid non-ASCII names" {
     const allocator = std.testing.allocator;
     const name = "seq_\u{20ac}_α";
 
@@ -381,7 +485,7 @@ test "renderJsonEvent preserves valid non-ASCII UTF-8 names" {
     try std.testing.expectEqualStrings(name, parsed.value.object.get("name").?.string);
 }
 
-test "renderJsonEvent escapes quotes and backslashes in names" {
+test "[unit] - [validate JSON]: escapes JSON syntax in names" {
     const allocator = std.testing.allocator;
     const name = "seq\"a\\b";
 
@@ -401,7 +505,7 @@ test "renderJsonEvent escapes quotes and backslashes in names" {
     try std.testing.expectEqualStrings(name, parsed.value.object.get("name").?.string);
 }
 
-test "renderJsonEvent escapes invalid UTF-8 name bytes" {
+test "[edge] - [validate JSON]: escapes invalid UTF-8 name bytes" {
     const allocator = std.testing.allocator;
     const bad_name = "seq\xffname";
 
@@ -423,27 +527,7 @@ test "renderJsonEvent escapes invalid UTF-8 name bytes" {
     try std.testing.expectEqualStrings("seq\u{00ff}name", parsed.value.object.get("name").?.string);
 }
 
-test "validateData to JSON keeps invalid UTF-8 header bytes escapable" {
-    const allocator = std.testing.allocator;
-    const fasta = ">bad\xffname\nACGT\n>bad\xffname\nTTTT\n";
-
-    var summary = try validator.validateData(allocator, fasta, .{});
-    defer summary.deinit(allocator);
-    try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .duplicate_name));
-
-    const event = summary.events.items[0];
-    try std.testing.expectEqual(validator.Kind.duplicate_name, event.kind);
-    try std.testing.expectEqualSlices(u8, "bad\xffname", event.name);
-
-    const json = try validator.renderJsonEvent(allocator, event);
-    defer allocator.free(json);
-    try std.testing.expect(std.unicode.utf8ValidateSlice(json));
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json, .{});
-    defer parsed.deinit();
-    try std.testing.expectEqualStrings("bad\u{00ff}name", parsed.value.object.get("name").?.string);
-}
-
-test "gates fixture: invalid UTF-8 names remain reportable" {
+test "[integration] - [validate JSON]: reports invalid UTF-8 fixture names as valid JSON" {
     const allocator = std.testing.allocator;
 
     const utf8_data = try readTestFile(allocator, "tests/data/gates/invalid_utf8_header.fasta");
@@ -461,25 +545,48 @@ test "gates fixture: invalid UTF-8 names remain reportable" {
     try std.testing.expect(std.mem.indexOf(u8, json, "\\u00ff") != null);
 }
 
-test "gates fixture: long headers remain visible" {
-    const allocator = std.testing.allocator;
+test "[property] - [validate alphabets]: accepts representative nucleotide and protein symbols" {
+    const cases = [_]struct {
+        sequence: []const u8,
+        sequence_type: main.stats.SequenceType,
+    }{
+        .{ .sequence = "ACGTNRYWSMKHBVDacgtnrywsmkhbvd", .sequence_type = .nucleotide },
+        .{ .sequence = "ACGUNRYWSMKHBVDacgunrywsmkhbvd", .sequence_type = .nucleotide },
+        .{ .sequence = "ACGTUacgtu", .sequence_type = .nucleotide },
+        .{ .sequence = "EFILPQXO*-efilpqxo", .sequence_type = .protein },
+    };
 
-    const long_data = try readTestFile(allocator, "tests/data/gates/long_header.fasta");
-    defer allocator.free(long_data);
-    var long_summary = try validator.validateData(allocator, long_data, .{});
-    defer long_summary.deinit(allocator);
-    try std.testing.expect(countKind(&long_summary, .long_header) >= 1);
+    for (cases) |case| {
+        const fasta = try std.fmt.allocPrint(std.testing.allocator, ">seq\n{s}\n", .{case.sequence});
+        defer std.testing.allocator.free(fasta);
+        var summary = try validator.validateData(std.testing.allocator, fasta, .{});
+        defer summary.deinit(std.testing.allocator);
+
+        try std.testing.expectEqual(@as(usize, 0), summary.events.items.len);
+        try std.testing.expectEqual(case.sequence_type, summary.sequence_type);
+        try std.testing.expectEqual(@as(u64, @intCast(case.sequence.len)), summary.type_bases_sampled);
+    }
 }
 
-test "validateData records type sample metadata" {
-    var summary = try validator.validateData(std.testing.allocator, ">seq\nACGT\n", .{});
-    defer summary.deinit(std.testing.allocator);
+test "[edge] - [validate headers]: warns only above the configured byte limit" {
+    const cases = [_]struct { fasta: []const u8, warning_count: usize }{
+        .{ .fasta = ">abc\nA\n", .warning_count = 0 },
+        .{ .fasta = ">abcd\nA\n", .warning_count = 1 },
+    };
 
-    try std.testing.expectEqual(main.stats.SequenceType.nucleotide, summary.sequence_type);
-    try std.testing.expectEqual(@as(u64, 4), summary.type_bases_sampled);
+    for (cases) |case| {
+        var summary = try validator.validateData(std.testing.allocator, case.fasta, .{ .max_header_len = 3 });
+        defer summary.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.warning_count, countKind(&summary, .long_header));
+        if (case.warning_count == 1) {
+            const event = summary.events.items[0];
+            try std.testing.expectEqual(@as(usize, 1), event.line);
+            try std.testing.expectEqual(@as(usize, 3), event.limit);
+        }
+    }
 }
 
-test "validate --json --summary reports sequence type sample fields" {
+test "[cli] - [validate JSON summary]: returns the complete stable schema" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -487,35 +594,21 @@ test "validate --json --summary reports sequence type sample fields" {
     const fasta_path = try writeFastaArtifact(allocator, "validate-type-json", ">seq\nACGT\n");
     defer std.Io.Dir.cwd().deleteFile(io, fasta_path) catch {};
 
-    var threaded = std.Io.Threaded.init(allocator, .{});
-    defer threaded.deinit();
-    const spawn_io = threaded.io();
-
-    const result = try std.process.run(allocator, spawn_io, .{
-        .argv = &.{ ZFASTA_BIN, "validate", "--json", "--summary", fasta_path },
-        .stdout_limit = .limited(64 * 1024),
-        .stderr_limit = .limited(64 * 1024),
-    });
-    defer allocator.free(result.stdout);
-    defer allocator.free(result.stderr);
-
-    switch (result.term) {
-        .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
-        else => return error.ChildProcessFailed,
-    }
-    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
-
-    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, std.mem.trim(u8, result.stdout, " \t\r\n"), .{});
-    defer parsed.deinit();
-    try std.testing.expectEqualStrings("nucleotide", parsed.value.object.get("sequence_type").?.string);
-    try std.testing.expectEqual(@as(i64, 4), parsed.value.object.get("type_bases_sampled").?.integer);
-    try std.testing.expectEqual(
-        @as(i64, @intCast(main.stats.VALIDATE_TYPE_SAMPLE_BASES)),
-        parsed.value.object.get("type_sample_cap").?.integer,
+    const expected = try std.fmt.allocPrint(
+        allocator,
+        "{{\"schema_version\":\"v1\",\"truncated\":false,\"sequence_type\":\"nucleotide\",\"type_bases_sampled\":4,\"type_sample_cap\":{d},\"counts\":{{\"no_sequences\":0,\"duplicate_name\":0,\"invalid_character\":0,\"null_byte\":0,\"utf8_bom\":0,\"inconsistent_line_widths\":0,\"trailing_whitespace\":0,\"empty_sequence\":0,\"missing_terminal_newline\":0,\"mixed_line_endings\":0,\"long_header\":0,\"schema_violation\":0}},\"first_examples\":{{}}}}\n",
+        .{main.stats.VALIDATE_TYPE_SAMPLE_BASES},
+    );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--json", "--summary", fasta_path },
+        0,
+        expected,
+        "",
     );
 }
 
-test "validateData reports missing terminal newline and invalid nucleotide character" {
+test "[edge] - [validate scan]: reports missing terminal newline and invalid nucleotide byte" {
     var summary = try validator.validateData(std.testing.allocator, ">seq\nACGTZ", .{});
     defer summary.deinit(std.testing.allocator);
 
@@ -523,7 +616,7 @@ test "validateData reports missing terminal newline and invalid nucleotide chara
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .invalid_character));
 }
 
-test "validateData custom alphabet overrides built-in alphabet" {
+test "[unit] - [validate alphabet]: custom symbols replace the detected alphabet" {
     var summary = try validator.validateData(std.testing.allocator, ">seq\nACGTZ\n", .{
         .custom_alphabet = "ACGTZ",
     });
@@ -532,7 +625,7 @@ test "validateData custom alphabet overrides built-in alphabet" {
     try std.testing.expectEqual(@as(usize, 0), countKind(&summary, .invalid_character));
 }
 
-test "validateData tracks line-width and trailing whitespace warnings" {
+test "[unit] - [validate layout]: reports width and trailing-whitespace warnings" {
     var summary = try validator.validateData(std.testing.allocator, ">seq\nAAAA\nCC \nGGGG\nTT\n", .{});
     defer summary.deinit(std.testing.allocator);
 
@@ -540,7 +633,7 @@ test "validateData tracks line-width and trailing whitespace warnings" {
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .inconsistent_line_widths));
 }
 
-test "validateData rejects a final sequence line wider than the established width" {
+test "[edge] - [validate layout]: reports a final line wider than the established width" {
     var summary = try validator.validateData(std.testing.allocator, ">seq\nAA\nAAAA\n", .{});
     defer summary.deinit(std.testing.allocator);
 
@@ -551,29 +644,33 @@ test "validateData rejects a final sequence line wider than the established widt
     try std.testing.expectEqual(@as(usize, 3), event.line);
 }
 
-test "validateData checks schemas" {
-    var uniprot = try validator.validateData(std.testing.allocator, ">sp|P12345|PROT_HUMAN\nMAV\n", .{
-        .schema = .uniprot,
-    });
-    defer uniprot.deinit(std.testing.allocator);
+test "[unit] - [validate schemas]: distinguishes valid and invalid UniProt and RefSeq headers" {
+    const cases = [_]struct {
+        fasta: []const u8,
+        schema: validator.Schema,
+        violations: usize,
+    }{
+        .{ .fasta = ">sp|P12345|PROT_HUMAN\nMAV\n", .schema = .uniprot, .violations = 0 },
+        .{ .fasta = ">P12345\nMAV\n", .schema = .uniprot, .violations = 1 },
+        .{ .fasta = ">NC_000001.11 Homo sapiens\nACGT\n", .schema = .refseq, .violations = 0 },
+        .{ .fasta = ">bad\nACGT\n", .schema = .refseq, .violations = 1 },
+    };
 
-    var refseq = try validator.validateData(std.testing.allocator, ">bad\nACGT\n", .{
-        .schema = .refseq,
-    });
-    defer refseq.deinit(std.testing.allocator);
-
-    try std.testing.expectEqual(@as(usize, 0), countKind(&uniprot, .schema_violation));
-    try std.testing.expectEqual(@as(usize, 1), countKind(&refseq, .schema_violation));
+    for (cases) |case| {
+        var summary = try validator.validateData(std.testing.allocator, case.fasta, .{ .schema = case.schema });
+        defer summary.deinit(std.testing.allocator);
+        try std.testing.expectEqual(case.violations, countKind(&summary, .schema_violation));
+    }
 }
 
-test "exitCode implements strict warning promotion" {
+test "[unit] - [validate status]: promotes warnings in strict mode" {
     try std.testing.expectEqual(@as(u8, 0), validator.exitCode(0, 0, false));
     try std.testing.expectEqual(@as(u8, 2), validator.exitCode(0, 1, false));
     try std.testing.expectEqual(@as(u8, 1), validator.exitCode(0, 1, true));
     try std.testing.expectEqual(@as(u8, 1), validator.exitCode(1, 0, false));
 }
 
-test "exitCodeForOptions ignores format warnings fixed by rewrite" {
+test "[unit] - [validate status]: ignores warnings repaired by format rewrite" {
     var summary = try validator.validateData(std.testing.allocator, ">seq\nACGT \n", .{});
     defer summary.deinit(std.testing.allocator);
 
@@ -582,20 +679,15 @@ test "exitCodeForOptions ignores format warnings fixed by rewrite" {
     try std.testing.expectEqual(@as(u8, 0), validator.exitCodeForOptions(&summary, .{ .fix = true }));
 }
 
-test "fixData idempotent: BOM, CRLF, trailing whitespace, width, missing newline" {
-    const broken = "\xEF\xBB\xBF>seq\r\nAAAA\r\nCC \r\nGGGG\r\nTT";
-    try expectFixIdempotent(std.testing.allocator, broken);
-}
+test "[property] - [validate fix]: is idempotent across supported layout rewrites" {
+    const cases = [_][]const u8{
+        "\xEF\xBB\xBF>seq\r\nAAAA\r\nCC \r\nGGGG\r\nTT",
+        ">seq\r\nAAAA\nCC\n",
+        ">seq\nACGT\n",
+    };
+    for (cases) |input| try expectFixIdempotent(std.testing.allocator, input);
 
-test "fixData idempotent: mixed line endings" {
-    const broken = ">seq\r\nAAAA\nCC\n";
-    try expectFixIdempotent(std.testing.allocator, broken);
-}
-
-test "fixData idempotent: already clean FASTA" {
-    const clean = ">seq\nACGT\n";
-    try expectFixIdempotent(std.testing.allocator, clean);
-
+    const clean = cases[2];
     var summary = try validator.validateData(std.testing.allocator, clean, .{});
     defer summary.deinit(std.testing.allocator);
     const fixed = try validator.fixData(std.testing.allocator, clean, summary.record_widths.items);
@@ -603,7 +695,7 @@ test "fixData idempotent: already clean FASTA" {
     try std.testing.expectEqualStrings(clean, fixed);
 }
 
-test "fixRejection blocks unfixable errors" {
+test "[failure] - [validate fix]: rejects errors outside the format-only contract" {
     var dup = try validator.validateData(std.testing.allocator, ">dup\nACGT\n>dup\nGCTA\n", .{});
     defer dup.deinit(std.testing.allocator);
     try std.testing.expectEqual(.duplicate_name, validator.fixRejection(&dup, .{}).?);
@@ -622,7 +714,7 @@ test "fixRejection blocks unfixable errors" {
     try std.testing.expectEqual(.null_byte, validator.fixRejection(&nulls, .{}).?);
 }
 
-test "fixData with fix-format-only preserves invalid characters" {
+test "[property] - [validate format-only fix]: preserves invalid sequence characters" {
     const broken = ">seq\nACGTZ\n";
     var summary = try validator.validateData(std.testing.allocator, broken, .{});
     defer summary.deinit(std.testing.allocator);
@@ -637,7 +729,7 @@ test "fixData with fix-format-only preserves invalid characters" {
     try std.testing.expectEqual(@as(usize, 1), countKind(&after, .invalid_character));
 }
 
-test "fixData does not remove empty sequence warnings" {
+test "[property] - [validate fix]: preserves empty-record warnings" {
     const broken = ">empty\n";
     var summary = try validator.validateData(std.testing.allocator, broken, .{});
     defer summary.deinit(std.testing.allocator);
@@ -651,9 +743,9 @@ test "fixData does not remove empty sequence warnings" {
     try std.testing.expectEqual(@as(usize, 1), countKind(&after, .empty_sequence));
 }
 
-// --- Integration tests ---
+// --- Fix and cross-module contracts ---
 
-test "validate --fix -o matches fixData rewrite" {
+test "[cli] - [validate fix]: replaces the output with the exact library rewrite" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -670,8 +762,8 @@ test "validate --fix -o matches fixData rewrite" {
     const expected = try validator.fixData(allocator, broken, summary.record_widths.items);
 
     const in_path = try writeFastaArtifact(allocator, "validate-fix-cli-in", broken);
-    const out_path = try writeFastaArtifact(allocator, "validate-fix-cli-out", "previous output\n");
     defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
+    const out_path = try writeFastaArtifact(allocator, "validate-fix-cli-out", "previous output\n");
     defer std.Io.Dir.cwd().deleteFile(io, out_path) catch {};
 
     var threaded = std.Io.Threaded.init(allocator, .{});
@@ -690,12 +782,53 @@ test "validate --fix -o matches fixData rewrite" {
         .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
         else => return error.ChildProcessFailed,
     }
+    try std.testing.expectEqualStrings(
+        "WARNING: line 2: trailing whitespace on sequence line in 'seq'\n",
+        result.stdout,
+    );
+    try std.testing.expectEqual(@as(usize, 0), result.stderr.len);
 
     const got = try readTestFile(allocator, out_path);
     try std.testing.expectEqualStrings(expected, got);
 }
 
-test "validate --fix rejects an alternate spelling of the input path" {
+test "[cli] - [validate format-only fix]: preserves invalid bytes while normal fix refuses" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const in_path = try writeFastaArtifact(allocator, "validate-format-only-in", ">seq\nACGTZ \n");
+    defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
+    const rejected_path = try utility.uniqueArtifactPath(allocator, "validate-fix-rejected", "fa");
+    defer std.Io.Dir.cwd().deleteFile(io, rejected_path) catch {};
+    const fixed_path = try utility.uniqueArtifactPath(allocator, "validate-format-only-out", "fa");
+    defer std.Io.Dir.cwd().deleteFile(io, fixed_path) catch {};
+
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--fix", "-o", rejected_path, in_path },
+        1,
+        "",
+        "error: validate --fix refuses character-level errors; use --fix-format-only to keep them unchanged\n",
+    );
+    try std.testing.expectError(
+        error.FileNotFound,
+        std.Io.Dir.cwd().openFile(io, rejected_path, .{}),
+    );
+
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--fix", "--fix-format-only", "-o", fixed_path, in_path },
+        1,
+        "WARNING: line 2: trailing whitespace on sequence line in 'seq'\n" ++
+            "ERROR: line 2: invalid sequence character 0x5a\n",
+        "",
+    );
+    const fixed = try readTestFile(allocator, fixed_path);
+    try std.testing.expectEqualStrings(">seq\nACGTZ\n", fixed);
+}
+
+test "[cli] - [validate fix]: rejects an aliased input path without modifying it" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -733,7 +866,7 @@ test "validate --fix rejects an alternate spelling of the input path" {
     try std.testing.expectEqualStrings(broken, input_after);
 }
 
-test "validate --fix succeeds after event list truncation" {
+test "[cli] - [validate fix]: writes a complete rewrite after report truncation" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
@@ -751,8 +884,8 @@ test "validate --fix succeeds after event list truncation" {
     try std.testing.expect(summary.truncated);
 
     const in_path = try writeFastaArtifact(allocator, "validate-fix-truncated-in", input.items);
-    const out_path = try utility.uniqueArtifactPath(allocator, "validate-fix-truncated-out", "fa");
     defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
+    const out_path = try utility.uniqueArtifactPath(allocator, "validate-fix-truncated-out", "fa");
     defer std.Io.Dir.cwd().deleteFile(io, out_path) catch {};
 
     var threaded = std.Io.Threaded.init(allocator, .{});
@@ -771,6 +904,23 @@ test "validate --fix succeeds after event list truncation" {
         .exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
         else => return error.ChildProcessFailed,
     }
+    var expected_stdout: std.ArrayList(u8) = .empty;
+    defer expected_stdout.deinit(allocator);
+    for (0..validator.MAX_VALIDATE_EVENTS) |event_index| {
+        const line = try std.fmt.allocPrint(
+            allocator,
+            "WARNING: line {d}: trailing whitespace on sequence line in 'seq'\n",
+            .{event_index + 2},
+        );
+        try expected_stdout.appendSlice(allocator, line);
+    }
+    try std.testing.expectEqualStrings(expected_stdout.items, result.stdout);
+    const expected_stderr = try std.fmt.allocPrint(
+        allocator,
+        "warning: validate event list truncated at {d}; --fix output was still written\n",
+        .{validator.MAX_VALIDATE_EVENTS},
+    );
+    try std.testing.expectEqualStrings(expected_stderr, result.stderr);
 
     const fixed = try readTestFile(allocator, out_path);
     var fixed_summary = try validator.validateData(allocator, fixed, .{});
@@ -778,72 +928,48 @@ test "validate --fix succeeds after event list truncation" {
     try std.testing.expectEqual(@as(usize, 0), fixed_summary.events.items.len);
 }
 
-test "format fix produces uniform indexed retrieval for crafted messy FASTA" {
-    const broken =
-        \\>messy_seq widths and trailing ws
-        \\AAAA    
-        \\CCCC
-        \\GGGGTT
-        \\
-    ;
-
+test "[integration] - [validate fix]: preserves indexed retrieval across layout rewrites" {
     var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
     defer arena.deinit();
     const allocator = arena.allocator();
-    const expected =
-        \\>messy_seq:1-14
-        \\AAAACCCCGGGGTT
-        \\
-    ;
+    const cases = [_]struct {
+        stem: []const u8,
+        broken: []const u8,
+        region: []const u8,
+        expected: []const u8,
+    }{
+        .{
+            .stem = "validate-fix-crafted",
+            .broken = ">messy_seq widths and trailing ws\nAAAA    \nCCCC\nGGGGTT\n",
+            .region = "messy_seq:1-14",
+            .expected = ">messy_seq:1-14\nAAAACCCCGGGGTT\n",
+        },
+        .{
+            .stem = "validate-fix-mixed",
+            .broken = ">mixed_widths internal line widths vary\nAAAACCCCGGGG\nTTTTAA\nAACCCCGGGGTT\nTT\n",
+            .region = "mixed_widths:3-24",
+            .expected = ">mixed_widths:3-24\nAACCCCGGGGTTTTAAAACCCC\n",
+        },
+        .{
+            .stem = "validate-fix-trailing",
+            .broken = ">trailing_whitespace spaces and tabs after sequence bytes\nAAAACCCC    \nGGGGTTTT\t\nCCCCAAAA\n",
+            .region = "trailing_whitespace:1-16",
+            .expected = ">trailing_whitespace:1-16\nAAAACCCCGGGGTTTT\n",
+        },
+    };
 
-    try expectFormatFixPreservesRegion(allocator, "validate-fix-crafted", broken, "messy_seq:1-14", expected);
+    for (cases) |case| {
+        try expectFormatFixPreservesRegion(
+            allocator,
+            case.stem,
+            case.broken,
+            case.region,
+            case.expected,
+        );
+    }
 }
 
-test "format fix preserves indexed retrieval for mixed_widths fixture" {
-    const broken = try readTestFile(
-        std.testing.allocator,
-        "bench/shared/cache/messy_fixtures/mixed_widths.fasta",
-    );
-    defer std.testing.allocator.free(broken);
-
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    const expected =
-        \\>mixed_widths:3-24
-        \\AACCCCGGGGTTTTAAAACCCC
-        \\
-    ;
-
-    try expectFormatFixPreservesRegion(allocator, "validate-fix-mixed", broken, "mixed_widths:3-24", expected);
-}
-
-test "format fix preserves indexed retrieval for trailing_whitespace fixture" {
-    const broken = try readTestFile(
-        std.testing.allocator,
-        "bench/shared/cache/messy_fixtures/trailing_whitespace.fasta",
-    );
-    defer std.testing.allocator.free(broken);
-
-    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
-    defer arena.deinit();
-    const allocator = arena.allocator();
-    const expected =
-        \\>trailing_whitespace:1-16
-        \\AAAACCCCGGGGTTTT
-        \\
-    ;
-
-    try expectFormatFixPreservesRegion(
-        allocator,
-        "validate-fix-trailing",
-        broken,
-        "trailing_whitespace:1-16",
-        expected,
-    );
-}
-
-test "validator and indexer agree on tests/data/validator_indexer_agreement.fasta" {
+test "[integration] - [validator and indexer]: agree on messy record catalog and geometry" {
     const data = try readTestFile(std.testing.allocator, "tests/data/validator_indexer_agreement.fasta");
     defer std.testing.allocator.free(data);
 

--- a/tests/test_validate.zig
+++ b/tests/test_validate.zig
@@ -3,13 +3,14 @@
 //! Also covers validator/indexer agreement on `tests/data/validator_indexer_agreement.fasta`.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const main = @import("main");
+const utility = @import("utility.zig");
 
 const io = std.testing.io;
 const validator = main.validator;
 
-const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+const ZFASTA_BIN = utility.ZFASTA_BIN;
+const expectCliResult = utility.expectCliResult;
 
 fn countKind(summary: *const validator.Summary, kind: validator.Kind) usize {
     var count: usize = 0;
@@ -61,15 +62,8 @@ fn readTestFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
     return data;
 }
 
-fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8) ![]u8 {
-    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.fa", .{ stem, nanos });
-}
-
 fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]u8 {
-    const path = try uniqueArtifactPath(allocator, stem);
+    const path = try utility.uniqueArtifactPath(allocator, stem, "fa");
     errdefer allocator.free(path);
     errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
     const file = try std.Io.Dir.cwd().createFile(io, path, .{});
@@ -184,6 +178,78 @@ fn zfiEmbeddedName(index: *const main.indexer.ZfiIndex, rec_idx: usize) []const 
 }
 
 // --- Unit tests ---
+
+test "[cli] - [validate]: rejects unknown options regardless of position" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+    const fasta = "tests/data/simple.fasta";
+
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", "--not-a-flag", fasta },
+        1,
+        "",
+        "error: unknown option: --not-a-flag\n",
+    );
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", fasta, "--not-a-flag" },
+        1,
+        "",
+        "error: unknown option: --not-a-flag\n",
+    );
+}
+
+test "[cli] - [validate]: rejects invalid option combinations and paths" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const cases = [_]struct { argv: []const []const u8, stderr: []const u8 }{
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--summary", "tests/data/simple.fasta" },
+            .stderr = "error: validate --summary requires --json\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "--fix-format-only", "tests/data/simple.fasta" },
+            .stderr = "error: validate --fix-format-only requires --fix\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "-o", "zig-cache/test-artifacts/unused.fasta", "tests/data/simple.fasta" },
+            .stderr = "error: validate -o requires --fix\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate" },
+            .stderr = "error: usage: z-fasta validate [options] <file.fasta>\n",
+        },
+        .{
+            .argv = &.{ ZFASTA_BIN, "validate", "tests/data/definitely-missing-cli-failure.fasta" },
+            .stderr = "error: file not found: tests/data/definitely-missing-cli-failure.fasta\n",
+        },
+    };
+    for (cases) |case| {
+        try expectCliResult(allocator, case.argv, 1, "", case.stderr);
+    }
+}
+
+test "[cli] - [validate]: warnings use exit 2 and exact stdout" {
+    var arena = std.heap.ArenaAllocator.init(std.testing.allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
+    const path = try writeFastaArtifact(allocator, "cli-validate-warn", ">empty_rec\n");
+    defer allocator.free(path);
+    defer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+
+    try expectCliResult(
+        allocator,
+        &.{ ZFASTA_BIN, "validate", path },
+        2,
+        "WARNING: line 1: empty sequence 'empty_rec'\n",
+        "",
+    );
+}
 
 test "validateData reports duplicate and empty sequence" {
     var summary = try validator.validateData(std.testing.allocator, ">dup\nAAAA\n>dup\n", .{});
@@ -685,7 +751,7 @@ test "validate --fix succeeds after event list truncation" {
     try std.testing.expect(summary.truncated);
 
     const in_path = try writeFastaArtifact(allocator, "validate-fix-truncated-in", input.items);
-    const out_path = try uniqueArtifactPath(allocator, "validate-fix-truncated-out");
+    const out_path = try utility.uniqueArtifactPath(allocator, "validate-fix-truncated-out", "fa");
     defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
     defer std.Io.Dir.cwd().deleteFile(io, out_path) catch {};
 

--- a/tests/test_validate.zig
+++ b/tests/test_validate.zig
@@ -52,6 +52,17 @@ fn fixAndFreeForAllocationCheck(allocator: std.mem.Allocator, data: []const u8) 
     defer allocator.free(fixed);
 }
 
+fn renderAndFreeForAllocationCheck(allocator: std.mem.Allocator, name: []const u8) !void {
+    const json = try validator.renderJsonEvent(allocator, .{
+        .level = .error_level,
+        .kind = .duplicate_name,
+        .line = 2,
+        .name = name,
+        .first_line = 1,
+    });
+    defer allocator.free(json);
+}
+
 fn fuzzValidator(_: void, smith: *std.testing.Smith) !void {
     var storage: [512]u8 = undefined;
     const data = storage[0..smith.slice(&storage)];
@@ -367,6 +378,11 @@ test "[failure] - [validate operations]: release partial allocations" {
         fixAndFreeForAllocationCheck,
         .{">seq\nAAAA \n"},
     );
+    try std.testing.checkAllAllocationFailures(
+        std.testing.allocator,
+        renderAndFreeForAllocationCheck,
+        .{"seq\"\\\xff"},
+    );
 }
 
 test "[fuzz] - [validate scan]: returns bounded summaries and idempotent allowed fixes" {
@@ -553,7 +569,7 @@ test "[property] - [validate alphabets]: accepts representative nucleotide and p
         .{ .sequence = "ACGTNRYWSMKHBVDacgtnrywsmkhbvd", .sequence_type = .nucleotide },
         .{ .sequence = "ACGUNRYWSMKHBVDacgunrywsmkhbvd", .sequence_type = .nucleotide },
         .{ .sequence = "ACGTUacgtu", .sequence_type = .nucleotide },
-        .{ .sequence = "EFILPQXO*-efilpqxo", .sequence_type = .protein },
+        .{ .sequence = "EFILPQBZJXUO*-efilpqbzjxuo", .sequence_type = .protein },
     };
 
     for (cases) |case| {
@@ -609,9 +625,10 @@ test "[cli] - [validate JSON summary]: returns the complete stable schema" {
 }
 
 test "[edge] - [validate scan]: reports missing terminal newline and invalid nucleotide byte" {
-    var summary = try validator.validateData(std.testing.allocator, ">seq\nACGTZ", .{});
+    var summary = try validator.validateData(std.testing.allocator, ">seq\nACGTACGTAC?", .{});
     defer summary.deinit(std.testing.allocator);
 
+    try std.testing.expectEqual(main.stats.SequenceType.nucleotide, summary.sequence_type);
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .missing_terminal_newline));
     try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .invalid_character));
 }
@@ -704,7 +721,7 @@ test "[failure] - [validate fix]: rejects errors outside the format-only contrac
     defer none.deinit(std.testing.allocator);
     try std.testing.expectEqual(.no_sequences, validator.fixRejection(&none, .{}).?);
 
-    var bad = try validator.validateData(std.testing.allocator, ">seq\nACGTZ\n", .{});
+    var bad = try validator.validateData(std.testing.allocator, ">seq\nACGT?\n", .{});
     defer bad.deinit(std.testing.allocator);
     try std.testing.expectEqual(.invalid_character, validator.fixRejection(&bad, .{}).?);
     try std.testing.expect(validator.fixRejection(&bad, .{ .fix_format_only = true }) == null);
@@ -715,14 +732,14 @@ test "[failure] - [validate fix]: rejects errors outside the format-only contrac
 }
 
 test "[property] - [validate format-only fix]: preserves invalid sequence characters" {
-    const broken = ">seq\nACGTZ\n";
+    const broken = ">seq\nACGT?\n";
     var summary = try validator.validateData(std.testing.allocator, broken, .{});
     defer summary.deinit(std.testing.allocator);
     try std.testing.expect(validator.fixRejection(&summary, .{ .fix_format_only = true }) == null);
 
     const fixed = try validator.fixData(std.testing.allocator, broken, summary.record_widths.items);
     defer std.testing.allocator.free(fixed);
-    try std.testing.expect(std.mem.indexOf(u8, fixed, "ACGTZ") != null);
+    try std.testing.expect(std.mem.indexOf(u8, fixed, "ACGT?") != null);
 
     var after = try validator.validateData(std.testing.allocator, fixed, .{});
     defer after.deinit(std.testing.allocator);
@@ -730,17 +747,21 @@ test "[property] - [validate format-only fix]: preserves invalid sequence charac
 }
 
 test "[property] - [validate fix]: preserves empty-record warnings" {
-    const broken = ">empty\n";
-    var summary = try validator.validateData(std.testing.allocator, broken, .{});
-    defer summary.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .empty_sequence));
+    const cases = [_][]const u8{ ">empty\n", ">empty" };
+    for (cases) |broken| {
+        var summary = try validator.validateData(std.testing.allocator, broken, .{});
+        defer summary.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), countKind(&summary, .empty_sequence));
 
-    const fixed = try validator.fixData(std.testing.allocator, broken, summary.record_widths.items);
-    defer std.testing.allocator.free(fixed);
+        const fixed = try validator.fixData(std.testing.allocator, broken, summary.record_widths.items);
+        defer std.testing.allocator.free(fixed);
+        try std.testing.expectEqualStrings(">empty\n", fixed);
 
-    var after = try validator.validateData(std.testing.allocator, fixed, .{});
-    defer after.deinit(std.testing.allocator);
-    try std.testing.expectEqual(@as(usize, 1), countKind(&after, .empty_sequence));
+        var after = try validator.validateData(std.testing.allocator, fixed, .{});
+        defer after.deinit(std.testing.allocator);
+        try std.testing.expectEqual(@as(usize, 1), countKind(&after, .empty_sequence));
+        try std.testing.expectEqual(@as(usize, 0), countKind(&after, .missing_terminal_newline));
+    }
 }
 
 // --- Fix and cross-module contracts ---
@@ -797,7 +818,7 @@ test "[cli] - [validate format-only fix]: preserves invalid bytes while normal f
     defer arena.deinit();
     const allocator = arena.allocator();
 
-    const in_path = try writeFastaArtifact(allocator, "validate-format-only-in", ">seq\nACGTZ \n");
+    const in_path = try writeFastaArtifact(allocator, "validate-format-only-in", ">seq\nACGT? \n");
     defer std.Io.Dir.cwd().deleteFile(io, in_path) catch {};
     const rejected_path = try utility.uniqueArtifactPath(allocator, "validate-fix-rejected", "fa");
     defer std.Io.Dir.cwd().deleteFile(io, rejected_path) catch {};
@@ -821,11 +842,11 @@ test "[cli] - [validate format-only fix]: preserves invalid bytes while normal f
         &.{ ZFASTA_BIN, "validate", "--fix", "--fix-format-only", "-o", fixed_path, in_path },
         1,
         "WARNING: line 2: trailing whitespace on sequence line in 'seq'\n" ++
-            "ERROR: line 2: invalid sequence character 0x5a\n",
+            "ERROR: line 2: invalid sequence character 0x3f\n",
         "",
     );
     const fixed = try readTestFile(allocator, fixed_path);
-    try std.testing.expectEqualStrings(">seq\nACGTZ\n", fixed);
+    try std.testing.expectEqualStrings(">seq\nACGT?\n", fixed);
 }
 
 test "[cli] - [validate fix]: rejects an aliased input path without modifying it" {

--- a/tests/utility.zig
+++ b/tests/utility.zig
@@ -1,0 +1,66 @@
+//! Shared process assertions and artifact paths for command test suites.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
+
+pub fn expectCliResult(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    exit_code: u8,
+    expected_stdout: []const u8,
+    expected_stderr: []const u8,
+) !void {
+    var threaded = std.Io.Threaded.init(allocator, .{});
+    defer threaded.deinit();
+    const result = try std.process.run(allocator, threaded.io(), .{
+        .argv = argv,
+        .stdout_limit = .limited(128 * 1024),
+        .stderr_limit = .limited(64 * 1024),
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .exited => |code| try std.testing.expectEqual(exit_code, code),
+        else => return error.ChildProcessFailed,
+    }
+    try std.testing.expectEqualStrings(expected_stdout, result.stdout);
+    try std.testing.expectEqualStrings(expected_stderr, result.stderr);
+}
+
+pub fn expectCliFailure(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    exit_code: u8,
+    expected_stderr: []const u8,
+) !void {
+    try expectCliResult(allocator, argv, exit_code, "", expected_stderr);
+}
+
+pub fn expectCliSuccess(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    expected_stdout: []const u8,
+) !void {
+    try expectCliResult(allocator, argv, 0, expected_stdout, "");
+}
+
+pub fn expectUnknownOptionRejected(
+    allocator: std.mem.Allocator,
+    argv: []const []const u8,
+    unknown: []const u8,
+) !void {
+    const expected = try std.fmt.allocPrint(allocator, "error: unknown option: {s}\n", .{unknown});
+    defer allocator.free(expected);
+    try expectCliFailure(allocator, argv, 1, expected);
+}
+
+pub fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8, ext: []const u8) ![]u8 {
+    const io = std.testing.io;
+    try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
+    const now = std.Io.Clock.Timestamp.now(io, .awake);
+    const nanos: u64 = @intCast(now.raw.toNanoseconds());
+    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.{s}", .{ stem, nanos, ext });
+}

--- a/tests/utility.zig
+++ b/tests/utility.zig
@@ -1,7 +1,8 @@
-//! Shared process assertions and artifact paths for command test suites.
+//! Shared test mechanics for command suites.
 
 const std = @import("std");
 const builtin = @import("builtin");
+const main = @import("main");
 
 pub const ZFASTA_BIN = if (builtin.os.tag == .windows) "zig-out\\bin\\z-fasta.exe" else "zig-out/bin/z-fasta";
 
@@ -60,7 +61,74 @@ pub fn expectUnknownOptionRejected(
 pub fn uniqueArtifactPath(allocator: std.mem.Allocator, stem: []const u8, ext: []const u8) ![]u8 {
     const io = std.testing.io;
     try std.Io.Dir.cwd().createDirPath(io, "zig-cache/test-artifacts");
-    const now = std.Io.Clock.Timestamp.now(io, .awake);
-    const nanos: u64 = @intCast(now.raw.toNanoseconds());
-    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{d}.{s}", .{ stem, nanos, ext });
+    var nonce_bytes: [16]u8 = undefined;
+    io.random(&nonce_bytes);
+    const nonce = std.mem.readInt(u128, &nonce_bytes, .little);
+    return std.fmt.allocPrint(allocator, "zig-cache/test-artifacts/{s}-{x}.{s}", .{ stem, nonce, ext });
+}
+
+pub fn writeFastaArtifact(allocator: std.mem.Allocator, stem: []const u8, data: []const u8) ![]u8 {
+    const io = std.testing.io;
+    const path = try uniqueArtifactPath(allocator, stem, "fa");
+    errdefer allocator.free(path);
+    errdefer std.Io.Dir.cwd().deleteFile(io, path) catch {};
+    const file = try std.Io.Dir.cwd().createFile(io, path, .{});
+    defer file.close(io);
+    try std.Io.File.writeStreamingAll(file, io, data);
+    return path;
+}
+
+pub fn writeZfi(
+    allocator: std.mem.Allocator,
+    fasta_path: []const u8,
+    data: []const u8,
+    enable_dedup: bool,
+) !void {
+    const io = std.testing.io;
+    var index = try main.indexer.scanZfiData(data, enable_dedup, allocator);
+    defer index.deinit(allocator);
+
+    var path_buffer: [4096]u8 = undefined;
+    const zfi_path = try std.fmt.bufPrint(&path_buffer, "{s}.zfi", .{fasta_path});
+    try main.indexer.writeZfiIndexFile(io, zfi_path, &index, data.len, try statMtimeNs(fasta_path));
+}
+
+pub fn captureExtractRegion(
+    allocator: std.mem.Allocator,
+    fasta_path: []const u8,
+    region: []const u8,
+) ![]u8 {
+    var index = try main.index_format.loadIndexChecked(allocator, std.testing.io, fasta_path);
+    defer index.deinit();
+
+    var output = std.Io.Writer.Allocating.init(allocator);
+    errdefer output.deinit();
+    main.getter.extractRegion(&index, region, &output.writer);
+    return output.toOwnedSlice();
+}
+
+pub fn statMtimeNs(path: []const u8) !u64 {
+    const io = std.testing.io;
+    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
+    defer file.close(io);
+    return main.index_format.timestampToNs((try file.stat(io)).mtime);
+}
+
+pub fn readRequiredFile(allocator: std.mem.Allocator, path: []const u8) ![]u8 {
+    const io = std.testing.io;
+    const file = std.Io.Dir.cwd().openFile(io, path, .{}) catch |err| switch (err) {
+        error.FileNotFound => {
+            std.debug.print("required test fixture missing: {s}\n", .{path});
+            return error.RequiredFixtureMissing;
+        },
+        else => |e| return e,
+    };
+    defer file.close(io);
+    const stat = try file.stat(io);
+    const size = std.math.cast(usize, stat.size) orelse return error.FileTooBig;
+    const data = try allocator.alloc(u8, size);
+    errdefer allocator.free(data);
+    const bytes_read = try file.readPositionalAll(io, data, 0);
+    if (bytes_read != data.len) return error.UnexpectedEndOfFile;
+    return data;
 }


### PR DESCRIPTION
## Summary

  - Standardizes ownership, cleanup, errors, naming, and Zig 0.16 usage across the codebase.
  - Consolidates and hardens CLI, property, fuzz, fixture, and failure-path tests.
  - Fixes edge cases in CLI and BED parsing, indexed reads, atomic output, and validation.

  ## Verification

  - Debug and ReleaseFast tests pass.
  - ReleaseFast production build passes.
  - No `.zfi` format change. Re-indexing is not required.